### PR TITLE
 Change relative imports to absolute imports 

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 from timeit import default_timer as timer
 from pathlib import Path
@@ -66,5 +67,6 @@ def example():
     
     return
 
-
+if __name__=='__main__':
+    example()
 

--- a/jigsawpy/__init__.py
+++ b/jigsawpy/__init__.py
@@ -50,45 +50,42 @@
 ------------------------------------------------------------
  """
 
-from .msh_t import jigsaw_msh_t
-from .jig_t import jigsaw_jig_t
+from jigsawpy.msh_t import jigsaw_msh_t
+from jigsawpy.jig_t import jigsaw_jig_t
 
-from .def_l import *
+from jigsawpy.def_l import *
 
-from .loadmsh import loadmsh
-from .savemsh import savemsh
-from .loadjig import loadjig
-from .savejig import savejig
+from jigsawpy.loadmsh import loadmsh
+from jigsawpy.savemsh import savemsh
+from jigsawpy.loadjig import loadjig
+from jigsawpy.savejig import savejig
 
-from .certify import certify
+from jigsawpy.certify import certify
+from jigsawpy import jigsaw, libsaw
 
 class cmd :
 #--------------------------------- expose cmd-line interface
     def jigsaw(opts,mesh=None) :
-        from  .jigsaw import jigsaw        
         
-        return jigsaw(opts,mesh)
+        return jigsaw.jigsaw(opts,mesh)
 
     def tripod(opts,tria=None) :
-        from  .jigsaw import tripod        
         
-        return tripod(opts,tria)
+        return jigsaw.tripod(opts,tria)
 
 class lib :
 #--------------------------------- expose API-lib. interface
     def jigsaw(opts,geom,mesh,
                init=None,
                hfun=None) :
-        from  .libsaw import jigsaw        
         
-        return jigsaw(
+        return libsaw.jigsaw(
             opts,geom,mesh,init,hfun)
 
     def tripod(opts,init,tria,
                geom=None) :
-        from  .libsaw import tripod        
         
-        return tripod(
+        return libsaw.tripod(
             opts,init,tria,geom     )
 
 

--- a/jigsawpy/certify.py
+++ b/jigsawpy/certify.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from .msh_t import jigsaw_msh_t
+from jigsawpy.msh_t import jigsaw_msh_t
 
 def certifyradii(data,stag):
 

--- a/jigsawpy/jig_l.py
+++ b/jigsawpy/jig_l.py
@@ -1,7 +1,7 @@
 
 import ctypes as ct
 
-from .def_l import indx_t, real_t
+from jigsawpy.def_l import indx_t, real_t
 
 #---------------------------- ctypes struct for JIGSAW's API
 

--- a/jigsawpy/jigsaw.py
+++ b/jigsawpy/jigsaw.py
@@ -5,11 +5,11 @@ import shutil
 
 from  pathlib import Path
 
-from .jig_t import jigsaw_jig_t
-from .msh_t import jigsaw_msh_t
+from jigsawpy.jig_t import jigsaw_jig_t
+from jigsawpy.msh_t import jigsaw_msh_t
 
-from .loadmsh import loadmsh
-from .savejig import savejig
+from jigsawpy.loadmsh import loadmsh
+from jigsawpy.savejig import savejig
 
 def jigsaw(opts,mesh=None):
     """

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -5,26 +5,18 @@ import os
 
 from pathlib import Path
 
-from .def_l import *
+from jigsawpy.def_l import *
 
-from .msh_l import libsaw_VERT2_t
-from .msh_l import libsaw_VERT3_t
-from .msh_l import libsaw_EDGE2_t
-from .msh_l import libsaw_TRIA3_t
-from .msh_l import libsaw_QUAD4_t
-from .msh_l import libsaw_TRIA4_t
-from .msh_l import libsaw_HEXA8_t
-from .msh_l import libsaw_WEDG6_t
-from .msh_l import libsaw_PYRA5_t
-from .msh_l import libsaw_BOUND_t
-from .msh_l import libsaw_msh_t
+from jigsawpy.msh_l import libsaw_VERT2_t, libsaw_VERT3_t, libsaw_EDGE2_t, \
+    libsaw_TRIA3_t, libsaw_QUAD4_t, libsaw_TRIA4_t, libsaw_HEXA8_t, \
+    libsaw_WEDG6_t, libsaw_PYRA5_t, libsaw_BOUND_t, libsaw_msh_t
 
-from .jig_l import libsaw_jig_t
+from jigsawpy.jig_l import libsaw_jig_t
 
-from .certify import certify
+from jigsawpy.certify import certify
 
-from .jig_t import jigsaw_jig_t
-from .msh_t import jigsaw_msh_t
+from jigsawpy.jig_t import jigsaw_jig_t
+from jigsawpy.msh_t import jigsaw_msh_t
 
 #---------------------------- Try to find/load JIGSAW's API.
 

--- a/jigsawpy/loadjig.py
+++ b/jigsawpy/loadjig.py
@@ -1,6 +1,6 @@
 
 from pathlib import Path
-from .jig_t  import jigsaw_jig_t
+from jigsawpy.jig_t  import jigsaw_jig_t
 
 def loadjig(name,opts):
     """

--- a/jigsawpy/loadmsh.py
+++ b/jigsawpy/loadmsh.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 from pathlib import Path
-from  .msh_t import jigsaw_msh_t
+from jigsawpy.msh_t import jigsaw_msh_t
 
 def loadradii(mesh,file,ltag):
     """

--- a/jigsawpy/msh_l.py
+++ b/jigsawpy/msh_l.py
@@ -1,7 +1,7 @@
 
 import ctypes as ct
 
-from .def_l import indx_t, real_t
+from jigsawpy.def_l import indx_t, real_t
 
 #------------------------------------------- POINT struct.'s
 

--- a/jigsawpy/savejig.py
+++ b/jigsawpy/savejig.py
@@ -1,6 +1,6 @@
   
 from pathlib import Path
-from .jig_t  import jigsaw_jig_t
+from jigsawpy.jig_t  import jigsaw_jig_t
 
 def savechar(file,sval,stag):
 

--- a/jigsawpy/savemsh.py
+++ b/jigsawpy/savemsh.py
@@ -1,8 +1,8 @@
 
 import numpy as np
-from  pathlib import Path
-from .msh_t   import jigsaw_msh_t
-from .certify import certify
+from pathlib import Path
+from jigsawpy.msh_t import jigsaw_msh_t
+from jigsawpy.certify import certify
 
 def saveradii(mesh,file):
     """


### PR DESCRIPTION
Move all imports to the top of the file.

The first of this is, I believe, required in python 3.  The second is strongly encouraged for better performance and clarity.

This merge also `example.py` executable (adding execute permission, a "shebang" and and call to `example()` if the script is called as an executable.  I find this is easier to use and more what a python user would expect.