### PR TITLE
Suggestion: conform to PEP8 code style

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import jigsawpy
-
 from tests.case_1_ import case_1_
 from tests.case_2_ import case_2_
 from tests.case_3_ import case_3_
@@ -13,32 +11,33 @@ import argparse
 import matplotlib.pyplot as plt
 
 
-def example(IDnumber=1,savefigs=False):
+def example(IDnumber=1, savefigs=False):
 
-#--------------- don't disp. to screen, write to png backend
+    # --------------- don't disp. to screen, write to png backend
 
-    if savefigs: plt.switch_backend ("Agg")
+    if savefigs:
+        plt.switch_backend("Agg")
 
-#--------------- delegate to the individual example cases...
+# --------------- delegate to the individual example cases...
 
     filepath = os.path.join(
         os.path.abspath(
-        os.path.dirname(__file__)),"files")
+            os.path.dirname(__file__)), "files")
 
-    if   (IDnumber == +1):
-        case_1_(filepath,savefigs)
+    if (IDnumber == +1):
+        case_1_(filepath, savefigs)
 
     elif (IDnumber == +2):
-        case_2_(filepath,savefigs)
+        case_2_(filepath, savefigs)
 
     elif (IDnumber == +3):
-        case_3_(filepath,savefigs)
+        case_3_(filepath, savefigs)
 
     elif (IDnumber == +4):
-        case_4_(filepath,savefigs)
+        case_4_(filepath, savefigs)
 
     elif (IDnumber == +5):
-        case_5_(filepath,savefigs)
+        case_5_(filepath, savefigs)
 
     return
 
@@ -58,6 +57,3 @@ if __name__ == "__main__":
 
     example(IDnumber=args.IDnumber,
             savefigs=args.savefigs)
-
-
-

--- a/jigsawpy/__init__.py
+++ b/jigsawpy/__init__.py
@@ -1,13 +1,13 @@
 """
 ------------------------------------------------------------
  *
- *   ,o, ,o,       /                                
+ *   ,o, ,o,       /
  *    `   `  e88~88e  d88~\   /~~~8e Y88b    e    /
- *   888 888 88   88 C888         88b Y88b  d8b  / 
- *   888 888 "8b_d8"  Y88b   e88~-888  Y888/Y88b/  
- *   888 888  /        888D C88   888   Y8/  Y8/   
- *   88P 888 Cb      \_88P   "8b_-888    Y    Y     
- * \_8"       Y8""8D                                
+ *   888 888 88   88 C888         88b Y88b  d8b  /
+ *   888 888 "8b_d8"  Y88b   e88~-888  Y888/Y88b/
+ *   888 888  /        888D C88   888   Y8/  Y8/
+ *   88P 888 Cb      \_88P   "8b_-888    Y    Y
+ * \_8"       Y8""8D
  *
 ------------------------------------------------------------
  * JIGSAW: Interface to the JIGSAW meshing library.
@@ -22,29 +22,29 @@
  *
 ------------------------------------------------------------
  *
- * This program may be freely redistributed under the 
- * condition that the copyright notices (including this 
- * entire header) are not removed, and no compensation 
- * is received through use of the software.  Private, 
- * research, and institutional use is free.  You may 
- * distribute modified versions of this code UNDER THE 
- * CONDITION THAT THIS CODE AND ANY MODIFICATIONS MADE 
- * TO IT IN THE SAME FILE REMAIN UNDER COPYRIGHT OF THE 
- * ORIGINAL AUTHOR, BOTH SOURCE AND OBJECT CODE ARE 
- * MADE FREELY AVAILABLE WITHOUT CHARGE, AND CLEAR 
- * NOTICE IS GIVEN OF THE MODIFICATIONS.  Distribution 
- * of this code as part of a commercial system is 
- * permissible ONLY BY DIRECT ARRANGEMENT WITH THE 
- * AUTHOR.  (If you are not directly supplying this 
- * code to a customer, and you are instead telling them 
- * how they can obtain it for free, then you are not 
- * required to make any arrangement with me.) 
+ * This program may be freely redistributed under the
+ * condition that the copyright notices (including this
+ * entire header) are not removed, and no compensation
+ * is received through use of the software.  Private,
+ * research, and institutional use is free.  You may
+ * distribute modified versions of this code UNDER THE
+ * CONDITION THAT THIS CODE AND ANY MODIFICATIONS MADE
+ * TO IT IN THE SAME FILE REMAIN UNDER COPYRIGHT OF THE
+ * ORIGINAL AUTHOR, BOTH SOURCE AND OBJECT CODE ARE
+ * MADE FREELY AVAILABLE WITHOUT CHARGE, AND CLEAR
+ * NOTICE IS GIVEN OF THE MODIFICATIONS.  Distribution
+ * of this code as part of a commercial system is
+ * permissible ONLY BY DIRECT ARRANGEMENT WITH THE
+ * AUTHOR.  (If you are not directly supplying this
+ * code to a customer, and you are instead telling them
+ * how they can obtain it for free, then you are not
+ * required to make any arrangement with me.)
  *
  * Disclaimer:  Neither I nor: Columbia University, The
- * Massachusetts Institute of Technology, The 
+ * Massachusetts Institute of Technology, The
  * University of Sydney, nor The National Aeronautics
- * and Space Administration warrant this code in any 
- * way whatsoever.  This code is provided "as-is" to be 
+ * and Space Administration warrant this code in any
+ * way whatsoever.  This code is provided "as-is" to be
  * used at your own risk.
  *
 ------------------------------------------------------------
@@ -61,32 +61,31 @@ from jigsawpy.savejig import savejig
 
 from jigsawpy.certify import certify
 
-from jigsawpy  import jigsaw, libsaw
+from jigsawpy import jigsaw, libsaw
 
-class cmd :
-#--------------------------------- expose cmd-line interface
-    def jigsaw(opts,mesh=None) :
-        
-        return jigsaw.jigsaw(opts,mesh)
 
-    def tripod(opts,tria=None) :
-        
-        return jigsaw.tripod(opts,tria)
+class cmd:
+    # --------------------------------- expose cmd-line interface
+    def jigsaw(opts, mesh=None):
 
-class lib :
-#--------------------------------- expose API-lib. interface
-    def jigsaw(opts,geom,mesh,
+        return jigsaw.jigsaw(opts, mesh)
+
+    def tripod(opts, tria=None):
+
+        return jigsaw.tripod(opts, tria)
+
+
+class lib:
+    # --------------------------------- expose API-lib. interface
+    def jigsaw(opts, geom, mesh,
                init=None,
-               hfun=None) :
-        
+               hfun=None):
+
         return libsaw.jigsaw(
-            opts,geom,mesh,init,hfun)
+            opts, geom, mesh, init, hfun)
 
-    def tripod(opts,init,tria,
-               geom=None) :
-        
+    def tripod(opts, init, tria,
+               geom=None):
+
         return libsaw.tripod(
-            opts,init,tria,geom     )
-
-
-
+            opts, init, tria, geom)

--- a/jigsawpy/certify.py
+++ b/jigsawpy/certify.py
@@ -2,209 +2,210 @@
 import numpy as np
 from jigsawpy.msh_t import jigsaw_msh_t
 
-def certifyarray(data,stag):
+
+def certifyarray(data, stag):
 
     if (data is not None):
-        if (isinstance(data,np.ndarray)):
+        if (isinstance(data, np.ndarray)):
 
             return data.size >= +1
 
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     return False
 
 
-def certifyradii(data,stag):
+def certifyradii(data, stag):
 
     if (data.size != +3):
-        raise Exception("Invalid "+stag+" size.")
-    
+        raise Exception("Invalid " + stag + " size.")
+
     if (data.ndim != +1):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.dtype != jigsaw_msh_t.REALS_t):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (np.any(data <= 0.)):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
-def certifypoint(data,stag,KIND):
+def certifypoint(data, stag, KIND):
 
     if (data.ndim != +1):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.dtype != KIND):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data["coord"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (not np.isfinite(data["IDtag"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
-def certifyvalue(vals,stag,nval):
+def certifyvalue(vals, stag, nval):
 
     if (vals.ndim != +2):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (vals.dtype != jigsaw_msh_t.REALS_t):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
-def certifycells(cell,stag,KIND):
+def certifycells(cell, stag, KIND):
 
     if (cell.ndim != +1):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (cell.dtype != KIND):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(cell["index"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (np.any(cell["index"] < +0)):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (not np.isfinite(cell["IDtag"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
-def certifyindex(data,stag,KIND):
+def certifyindex(data, stag, KIND):
 
     if (data.ndim != +1):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.dtype != KIND):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data["IDtag"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (not np.isfinite(data["index"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (np.any(data["index"] < +0)):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (not np.isfinite(data["cells"]).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     if (np.any(data["cells"] < +0)):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
 def certifymesht(mesh):
 
-    if (certifyarray(mesh.radii,"MESH.RADII")):
+    if (certifyarray(mesh.radii, "MESH.RADII")):
 
-        certifyradii(mesh.radii,"MESH.RADII")
+        certifyradii(mesh.radii, "MESH.RADII")
 
-    if (certifyarray(mesh.vert2,"MESH.VERT2")):
+    if (certifyarray(mesh.vert2, "MESH.VERT2")):
 
-        certifypoint(mesh.vert2,"MESH.VERT2", \
-            jigsaw_msh_t.VERT2_t)
+        certifypoint(mesh.vert2, "MESH.VERT2",
+                     jigsaw_msh_t.VERT2_t)
 
-    if (certifyarray(mesh.vert3,"MESH.VERT3")):
+    if (certifyarray(mesh.vert3, "MESH.VERT3")):
 
-        certifypoint(mesh.vert3,"MESH.VERT3", \
-            jigsaw_msh_t.VERT3_t)
+        certifypoint(mesh.vert3, "MESH.VERT3",
+                     jigsaw_msh_t.VERT3_t)
 
-    if (certifyarray(mesh.power,"MESH.POWER")):
+    if (certifyarray(mesh.power, "MESH.POWER")):
 
-        certifyvalue(mesh.power,"MESH.POWER")
+        certifyvalue(mesh.power, "MESH.POWER")
 
-    if (certifyarray(mesh.value,"MESH.VALUE")):
+    if (certifyarray(mesh.value, "MESH.VALUE")):
 
-        certifyvalue(mesh.value,"MESH.VALUE")
+        certifyvalue(mesh.value, "MESH.VALUE")
 
-    if (certifyarray(mesh.edge2,"MESH.EDGE2")):
+    if (certifyarray(mesh.edge2, "MESH.EDGE2")):
 
-        certifycells(mesh.edge2,"MESH.EDGE2", \
-            jigsaw_msh_t.EDGE2_t)
+        certifycells(mesh.edge2, "MESH.EDGE2",
+                     jigsaw_msh_t.EDGE2_t)
 
-    if (certifyarray(mesh.tria3,"MESH.TRIA3")):
+    if (certifyarray(mesh.tria3, "MESH.TRIA3")):
 
-        certifycells(mesh.tria3,"MESH.TRIA3", \
-            jigsaw_msh_t.TRIA3_t)
+        certifycells(mesh.tria3, "MESH.TRIA3",
+                     jigsaw_msh_t.TRIA3_t)
 
-    if (certifyarray(mesh.quad4,"MESH.QUAD4")):
+    if (certifyarray(mesh.quad4, "MESH.QUAD4")):
 
-        certifycells(mesh.quad4,"MESH.QUAD4", \
-            jigsaw_msh_t.QUAD4_t)
+        certifycells(mesh.quad4, "MESH.QUAD4",
+                     jigsaw_msh_t.QUAD4_t)
 
-    if (certifyarray(mesh.tria4,"MESH.TRIA4")):
+    if (certifyarray(mesh.tria4, "MESH.TRIA4")):
 
-        certifycells(mesh.tria4,"MESH.TRIA4", \
-            jigsaw_msh_t.TRIA4_t)
+        certifycells(mesh.tria4, "MESH.TRIA4",
+                     jigsaw_msh_t.TRIA4_t)
 
-    if (certifyarray(mesh.hexa8,"MESH.HEXA8")):
+    if (certifyarray(mesh.hexa8, "MESH.HEXA8")):
 
-        certifycells(mesh.hexa8,"MESH.HEXA8", \
-            jigsaw_msh_t.HEXA8_t)
+        certifycells(mesh.hexa8, "MESH.HEXA8",
+                     jigsaw_msh_t.HEXA8_t)
 
-    if (certifyarray(mesh.wedg6,"MESH.WEDG6")):
+    if (certifyarray(mesh.wedg6, "MESH.WEDG6")):
 
-        certifycells(mesh.wedg6,"MESH.WEDG6", \
-            jigsaw_msh_t.WEDG6_t)
+        certifycells(mesh.wedg6, "MESH.WEDG6",
+                     jigsaw_msh_t.WEDG6_t)
 
-    if (certifyarray(mesh.pyra5,"MESH.PYRA5")):
+    if (certifyarray(mesh.pyra5, "MESH.PYRA5")):
 
-        certifycells(mesh.pyra5,"MESH.PYRA5", \
-            jigsaw_msh_t.PYRA5_t)
+        certifycells(mesh.pyra5, "MESH.PYRA5",
+                     jigsaw_msh_t.PYRA5_t)
 
-    if (certifyarray(mesh.bound,"MESH.BOUND")):
+    if (certifyarray(mesh.bound, "MESH.BOUND")):
 
-        certifyindex(mesh.bound,"MESH.BOUND", \
-            jigsaw_msh_t.BOUND_t)
+        certifyindex(mesh.bound, "MESH.BOUND",
+                     jigsaw_msh_t.BOUND_t)
 
     return
 
 
-def certifycoord(data,stag):
+def certifycoord(data, stag):
 
     if (data.ndim != +1):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.dtype != jigsaw_msh_t.REALS_t):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
 
-def certifyNDmat(data,stag,dims):
+def certifyNDmat(data, stag, dims):
 
     if (data.ndim != len(dims)):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.size != np.prod(dims)):
-        raise Exception("Invalid "+stag+" size.")
+        raise Exception("Invalid " + stag + " size.")
 
     if (data.dtype != jigsaw_msh_t.REALS_t):
-        raise Exception("Invalid "+stag+" type.")
+        raise Exception("Invalid " + stag + " type.")
 
     if (not np.isfinite(data).all()):
-        raise Exception("Invalid "+stag+" data.")
+        raise Exception("Invalid " + stag + " data.")
 
     return
 
@@ -213,31 +214,31 @@ def certifygridt(mesh):
 
     dims = []
 
-    if (certifyarray(mesh.radii,"MESH.RADII")):
+    if (certifyarray(mesh.radii, "MESH.RADII")):
 
-        certifyradii(mesh.radii,"MESH.RADII")
+        certifyradii(mesh.radii, "MESH.RADII")
 
-    if (certifyarray(mesh.xgrid,"MESH.XGRID")):
+    if (certifyarray(mesh.xgrid, "MESH.XGRID")):
 
-        dims +=[mesh.xgrid.size]
+        dims += [mesh.xgrid.size]
 
-        certifycoord(mesh.xgrid,"MESH.XGRID")
+        certifycoord(mesh.xgrid, "MESH.XGRID")
 
-    if (certifyarray(mesh.ygrid,"MESH.YGRID")):
+    if (certifyarray(mesh.ygrid, "MESH.YGRID")):
 
-        dims +=[mesh.ygrid.size]
+        dims += [mesh.ygrid.size]
 
-        certifycoord(mesh.ygrid,"MESH.YGRID")
+        certifycoord(mesh.ygrid, "MESH.YGRID")
 
-    if (certifyarray(mesh.zgrid,"MESH.ZGRID")):
+    if (certifyarray(mesh.zgrid, "MESH.ZGRID")):
 
-        dims +=[mesh.zgrid.size]
+        dims += [mesh.zgrid.size]
 
-        certifycoord(mesh.zgrid,"MESH.ZGRID")
+        certifycoord(mesh.zgrid, "MESH.ZGRID")
 
-    if (certifyarray(mesh.value,"MESH.VALUE")):
+    if (certifyarray(mesh.value, "MESH.VALUE")):
 
-        certifyNDmat(mesh.value,"MESH.VALUE", \
+        certifyNDmat(mesh.value, "MESH.VALUE",
                      dims)
 
     return
@@ -246,33 +247,31 @@ def certifygridt(mesh):
 def certify(mesh):
     """
     CERTIFY: certify layout for a JIGSAW MSH object.
-    
+
     """
 
-    if (mesh is None): return
+    if (mesh is None):
+        return
 
-    if (not isinstance (mesh,jigsaw_msh_t)):
+    if (not isinstance(mesh, jigsaw_msh_t)):
         raise Exception("Invalid MESH structure.")
 
-    if (not isinstance (mesh.mshID,str)):
+    if (not isinstance(mesh.mshID, str)):
         raise Exception("Invalid MESH.MSHID tag.")
 
-    if (mesh.mshID.lower() \
-            in ["euclidean-mesh","ellipsoid-mesh"
-                    ]   ):
-    #---------------------------------- certify MESH struct.
+    if (mesh.mshID.lower()
+            in ["euclidean-mesh", "ellipsoid-mesh"
+                ]):
+        # ---------------------------------- certify MESH struct.
         certifymesht(mesh)
-                  
-    elif (mesh.mshID.lower() \
-            in ["euclidean-grid","ellipsoid-grid"
-                    ]   ):
-    #---------------------------------- certify GRID struct.
+
+    elif (mesh.mshID.lower()
+            in ["euclidean-grid", "ellipsoid-grid"
+                ]):
+        # ---------------------------------- certify GRID struct.
         certifygridt(mesh)
 
     else:
         raise Exception("Invalid MESH.MSHID tag.")
- 
+
     return
-
-
-

--- a/jigsawpy/def_t.py
+++ b/jigsawpy/def_t.py
@@ -4,47 +4,45 @@ import ctypes as ct
 indx_t = ct.c_int32
 real_t = ct.c_double
 
+
 class jigsaw_def_t:
-#--------------------------------- return codes for JIGSAW .
+    # --------------------------------- return codes for JIGSAW .
 
-    JIGSAW_UNKNOWN_ERROR    = -  1
+    JIGSAW_UNKNOWN_ERROR = -  1
 
-    JIGSAW_NO_ERROR         = +  0
+    JIGSAW_NO_ERROR = +  0
 
     JIGSAW_FILE_NOT_LOCATED = +  2
     JIGSAW_FILE_NOT_CREATED = +  3
 
     JIGSAW_INVALID_ARGUMENT = +  4
 
-#--------------------------------- constants for libJIGSAW .
+# --------------------------------- constants for libJIGSAW .
 
-    JIGSAW_NULL_FLAG        = -100
+    JIGSAW_NULL_FLAG = -100
 
-    JIGSAW_EUCLIDEAN_MESH   = +100
-    JIGSAW_EUCLIDEAN_GRID   = +101
-    JIGSAW_EUCLIDEAN_DUAL   = +102
-        
-    JIGSAW_ELLIPSOID_MESH   = +200
-    JIGSAW_ELLIPSOID_GRID   = +201
-    JIGSAW_ELLIPSOID_DUAL   = +202
+    JIGSAW_EUCLIDEAN_MESH = +100
+    JIGSAW_EUCLIDEAN_GRID = +101
+    JIGSAW_EUCLIDEAN_DUAL = +102
 
-    JIGSAW_POINT_TAG        = + 10
-    JIGSAW_EDGE2_TAG        = + 20
-    JIGSAW_TRIA3_TAG        = + 30
-    JIGSAW_QUAD4_TAG        = + 40
-    JIGSAW_TRIA4_TAG        = + 50
-    JIGSAW_HEXA8_TAG        = + 60
-    JIGSAW_WEDG6_TAG        = + 70
-    JIGSAW_PYRA5_TAG        = + 80
+    JIGSAW_ELLIPSOID_MESH = +200
+    JIGSAW_ELLIPSOID_GRID = +201
+    JIGSAW_ELLIPSOID_DUAL = +202
 
-    JIGSAW_HFUN_RELATIVE    = +300
-    JIGSAW_HFUN_ABSOLUTE    = +301
-        
-    JIGSAW_KERN_DELFRONT    = +400
-    JIGSAW_KERN_DELAUNAY    = +401
+    JIGSAW_POINT_TAG = + 10
+    JIGSAW_EDGE2_TAG = + 20
+    JIGSAW_TRIA3_TAG = + 30
+    JIGSAW_QUAD4_TAG = + 40
+    JIGSAW_TRIA4_TAG = + 50
+    JIGSAW_HEXA8_TAG = + 60
+    JIGSAW_WEDG6_TAG = + 70
+    JIGSAW_PYRA5_TAG = + 80
 
-    JIGSAW_BNDS_TRIACELL    = +402
-    JIGSAW_BNDS_DUALCELL    = +403
+    JIGSAW_HFUN_RELATIVE = +300
+    JIGSAW_HFUN_ABSOLUTE = +301
 
+    JIGSAW_KERN_DELFRONT = +400
+    JIGSAW_KERN_DELAUNAY = +401
 
-
+    JIGSAW_BNDS_TRIACELL = +402
+    JIGSAW_BNDS_DUALCELL = +403

--- a/jigsawpy/jig_l.py
+++ b/jigsawpy/jig_l.py
@@ -3,246 +3,244 @@ import ctypes as ct
 
 from jigsawpy.def_t import indx_t, real_t
 
-#---------------------------- ctypes struct for JIGSAW's API
+# ---------------------------- ctypes struct for JIGSAW's API
+
 
 class libsaw_jig_t(ct.Structure):
     _fields_ = [
 
-    # VERBOSITY - {default=0} verbosity of log-file gene-
-    # rated by JIGSAW. Set VERBOSITY > 0 for more output.
-    
-    ("verbosity",  indx_t) ,
+        # VERBOSITY - {default=0} verbosity of log-file gene-
+        # rated by JIGSAW. Set VERBOSITY > 0 for more output.
 
-    # GEOM-SEED - {default = 8} number of "seed" vertices 
-    # used to initialise mesh generation.
-          
-    ("geom_seed",  indx_t) ,
-        
-    # GEOM_FEAT - {default = false} attempt to auto-detect 
-    # "sharp-features" in the input geometry. Features can 
-    # lie adjacent to 1-dim. entities, (i.e. geometry 
-    # "edges") and/or 2-dim. entities, (i.e. geometry 
-    # "faces") based on both geometrical and/or topologic-
-    # al constraints. Geometrically, features are located 
-    # between any neighbouring entities that subtend 
-    # angles less than GEOM_ETAX degrees, where "X" is the 
-    # (topological) dimension of the feature. Topological-
-    # ly, features are located at the apex of any non-man-
-    # ifold connections.
-        
-    ("geom_feat",  indx_t) ,
-        
-    # GEOM_ETA1 - {default = 45deg} 1-dim. feature-angle, 
-    # features are located between any neighbouring 
-    # "edges" that subtend angles less than ETA1 deg.
-        
-    ("geom_eta1",  real_t) ,
-        
-    # GEOM_ETA2 - {default = 45deg} 2-dim. feature-angle, 
-    # features are located between any neighbouring 
-    # "faces" that subtend angles less than ETA2 deg.
-        
-    ("geom_eta2",  real_t) ,
-             
-    # INIT_NEAR - {default = 1.E-8} relative "zip" tol.
-    # applied when processing initial conditions. In cases
-    # where "sharp-feature" detection is active, nodes in 
-    # the initial set are zipped to their nearest feature
-    # node if the separation length is less than NEAR*SCAL
-    # where SCAL is the max. bounding-box dimension. 
-    
-    ("init_near",  real_t) ,
+        ("verbosity", indx_t),
 
-    # HFUN_SCAL - {default = 'relative'} scaling type for 
-    # mesh-size fuction. HFUN_SCAL='relative' interprets 
-    # mesh-size values as percentages of the (mean) length 
-    # of the axis-aligned bounding-box (AABB) associated 
-    # with the geometry. HFUN_SCAL = 'absolute' interprets 
-    # mesh-size values as absolute measures.
-        
-    ("hfun_scal",  indx_t) ,     
-       
-    # HFUN_HMAX - {default = 0.02} max. mesh-size function 
-    # value. Interpreted based on SCAL setting.
-     
-    ("hfun_hmax",  real_t) ,
-        
-    # HFUN_HMIN - {default = 0.00} min. mesh-size function 
-    # value. Interpreted based on SCAL setting.
-     
-    ("hfun_hmin",  real_t) ,
-        
-    # BNDS_KERN - {default = 'bnd-tria'} placement of bou-
-    # ndary, enforcing conformance w.r.t the triangulation 
-    # (KERN='bnd-tria') or w.r.t the dual voronoi complex 
-    # (KERN='bnd-dual').
-        
-    ("bnds_kern",  indx_t) ,
-            
-    # MESH_DIMS - {default=+3} number of "topological" di-
-    # mensions to mesh. DIMS=K meshes K-dimensional featu-
-    # res, irrespective of the number of spatial dim.'s of 
-    # the problem (i.e. if the geometry is 3-dimensional 
-    # and DIMS=2 a surface mesh will be produced).
-        
-    ("mesh_dims",  indx_t) ,        
-    
-    # MESH_KERN - {default = 'delfront'} meshing kernal,
-    # choice of the standard Delaunay-refinement algorithm 
-    # (KERN='delaunay') or the Frontal-Delaunay method 
-    # (KERN='delfront').
-        
-    ("mesh_kern",  indx_t) ,
-       
-    # MESH_ITER - {default = INF} max. number of mesh ref-
-    # inement iterations. Set ITER=N to see progress after 
-    # N iterations.
-    
-    ("mesh_iter",  indx_t) ,
-       
-    # MESH_TOP1 - {default=false} enforce 1-dim. topolog-
-    # ical constraints. 1-dim. edges are refined until all 
-    # embedded nodes are "locally 1-manifold", i.e. nodes 
-    # are either centred at topological "features", or lie 
-    # on 1-manifold complexes.
-    
-    ("mesh_top1",  indx_t) ,     
-       
-    # MESH_TOP2 - {default=false} enforce 2-dim. topolog-
-    # ical constraints. 2-dim. trias are refined until all 
-    # embedded nodes are "locally 2-manifold", i.e. nodes 
-    # are either centred at topological "features", or lie 
-    # on 2-manifold complexes.
-       
-    ("mesh_top2",  indx_t) ,
-        
-    # MESH_RAD2 - {default = 1.05} max. radius-edge ratio 
-    # for 2-tria elements. 2-trias are refined until the 
-    # ratio of the element circumradii to min. edge length 
-    # is less-than RAD2.
-       
-    ("mesh_rad2",  real_t) ,
-        
-    # MESH_RAD3 - {default = 2.05} max. radius-edge ratio 
-    # for 3-tria elements. 3-trias are refined until the 
-    # ratio of the element circumradii to min. edge length 
-    # is less-than RAD3.
-       
-    ("mesh_rad3",  real_t) ,
-    
-    # MESH_SIZ1 - {default=4/3+eps} h(x)-based refinement
-    # multiplier for 1-dimensional elements. Edges are 
-    # refined if they are locally larger than SIZ1 * h(x). 
-        
-    ("mesh_siz1",  real_t) ,
-       
-    # MESH_SIZ2 - {default=4/3+eps} h(x)-based refinement
-    # multiplier for 2-dimensional elements. Cells are 
-    # refined if they are locally larger than SIZ2 * h(x). 
-        
-    ("mesh_siz2",  real_t) ,
-        
-    # MESH_SIZ3 - {default=4/3+eps} h(x)-based refinement
-    # multiplier for 3-dimensional elements. Cells are 
-    # refined if they are locally larger than SIZ3 * h(x). 
-        
-    ("mesh_siz3",  real_t) ,
-        
-    # MESH_OFF2 - {default=0.90} radius-edge ratio target
-    # for insertion of "shape"-type offcentres for 2-tria
-    # elements. When refining an element II, offcentres
-    # are positioned to form a new "frontal" element JJ 
-    # that satisfies JRAD <= OFF2.
-    
-    ("mesh_off2",  real_t) ,
-       
-    # MESH_OFF3 - {default=1.10} radius-edge ratio target
-    # for insertion of "shape"-type offcentres for 3-tria
-    # elements. When refining an element II, offcentres
-    # are positioned to form a new "frontal" element JJ 
-    # that satisfies JRAD <= OFF3.
-     
-    ("mesh_off3",  real_t) ,
-       
-    # MESH_SNK2 - {default=0.20} inflation tolerance for
-    # insertion of "sink" offcentres for 2-tria elements.
-    # When refining an element II, "sinks" are positioned
-    # at the centre of the largest adj. circumball staisf-
-    # ying |JBAL-IBAL| < SNK2 * IRAD, where IRAD is the 
-    # radius of the circumball, and [IBAL,JBAL] are the 
-    # circumball centres.
-       
-    ("mesh_snk2",  real_t) ,
-       
-    # MESH_SNK3 - {default=0.33} inflation tolerance for
-    # insertion of "sink" offcentres for 3-tria elements.
-    # When refining an element II, "sinks" are positioned
-    # at the centre of the largest adj. circumball staisf-
-    # ying |JBAL-IBAL| < SNK3 * IRAD, where IRAD is the 
-    # radius of the circumball, and [IBAL,JBAL] are the 
-    # circumball centres.
-        
-    ("mesh_snk3",  real_t) ,
-       
-    # MESH_EPS1 - {default=0.33} max. surface-discretisa-
-    # tion error multiplier for 1-edge elements. 1-edge 
-    # elements are refined until the surface-disc. error 
-    # is less-than EPS1 * HFUN(X).
-        
-    ("mesh_eps1",  real_t) ,
-       
-    # MESH_EPS2 - {default=0.33} max. surface-discretisa-
-    # tion error multiplier for 2-tria elements. 2-tria 
-    # elements are refined until the surface-disc. error 
-    # is less-than EPS2 * HFUN(X).
-    
-    ("mesh_eps2",  real_t) ,
-       
-    # MESH_VOL3 - {default=0.00} min. volume-length ratio 
-    # for 3-tria elements. 3-tria elements are refined 
-    # until the volume-length ratio exceeds VOL3. Can be 
-    # used to supress "sliver" elements.
-        
-    ("mesh_vol3",  real_t) ,
-       
-    # OPTM_ITER - {default=16} max. number of mesh optim-
-    # isation iterations. Set ITER=N to see progress after 
-    # N iterations.
-    
-    ("optm_iter",  indx_t) ,
-       
-    # OPTM_QTOL - {default=1.E-04} tolerance on mesh cost
-    # function for convergence. Iteration on a given node
-    # is terminated if adjacent element cost-functions are
-    # improved by less than QTOL.
-       
-    ("optm_qtol",  real_t) ,
-       
-    # OPTM_QLIM - {default=0.9375} threshold on mesh cost
-    # function above which gradient-based optimisation is
-    # attempted.
-       
-    ("optm_qlim",  real_t) ,
- 
-    # OPTM_TRIA - {default= true} allow for optimisation
-    # of TRIA grid geometry.
-    
-    ("optm_tria",  indx_t) ,
-       
-    # OPTM_DUAL - {default=false} allow for optimisation
-    # of DUAL grid geometry.
-        
-    ("optm_dual",  indx_t) ,
-       
-    # OPTM_ZIP_ - {default= true} allow for "merge" oper-
-    # ations on sub-faces within the optimisation stages.
-        
-    ("optm_zip_",  indx_t) ,
-       
-    # OPTM_DIV_ - {default= true} allow for "split" oper-
-    # ations on sub-faces within the optimisation stages.
-        
-    ("optm_div_",  indx_t) ]
+        # GEOM-SEED - {default = 8} number of "seed" vertices
+        # used to initialise mesh generation.
 
+        ("geom_seed", indx_t),
 
+        # GEOM_FEAT - {default = false} attempt to auto-detect
+        # "sharp-features" in the input geometry. Features can
+        # lie adjacent to 1-dim. entities, (i.e. geometry
+        # "edges") and/or 2-dim. entities, (i.e. geometry
+        # "faces") based on both geometrical and/or topologic-
+        # al constraints. Geometrically, features are located
+        # between any neighbouring entities that subtend
+        # angles less than GEOM_ETAX degrees, where "X" is the
+        # (topological) dimension of the feature. Topological-
+        # ly, features are located at the apex of any non-man-
+        # ifold connections.
 
+        ("geom_feat", indx_t),
+
+        # GEOM_ETA1 - {default = 45deg} 1-dim. feature-angle,
+        # features are located between any neighbouring
+        # "edges" that subtend angles less than ETA1 deg.
+
+        ("geom_eta1", real_t),
+
+        # GEOM_ETA2 - {default = 45deg} 2-dim. feature-angle,
+        # features are located between any neighbouring
+        # "faces" that subtend angles less than ETA2 deg.
+
+        ("geom_eta2", real_t),
+
+        # INIT_NEAR - {default = 1.E-8} relative "zip" tol.
+        # applied when processing initial conditions. In cases
+        # where "sharp-feature" detection is active, nodes in
+        # the initial set are zipped to their nearest feature
+        # node if the separation length is less than NEAR*SCAL
+        # where SCAL is the max. bounding-box dimension.
+
+        ("init_near", real_t),
+
+        # HFUN_SCAL - {default = 'relative'} scaling type for
+        # mesh-size fuction. HFUN_SCAL='relative' interprets
+        # mesh-size values as percentages of the (mean) length
+        # of the axis-aligned bounding-box (AABB) associated
+        # with the geometry. HFUN_SCAL = 'absolute' interprets
+        # mesh-size values as absolute measures.
+
+        ("hfun_scal", indx_t),
+
+        # HFUN_HMAX - {default = 0.02} max. mesh-size function
+        # value. Interpreted based on SCAL setting.
+
+        ("hfun_hmax", real_t),
+
+        # HFUN_HMIN - {default = 0.00} min. mesh-size function
+        # value. Interpreted based on SCAL setting.
+
+        ("hfun_hmin", real_t),
+
+        # BNDS_KERN - {default = 'bnd-tria'} placement of bou-
+        # ndary, enforcing conformance w.r.t the triangulation
+        # (KERN='bnd-tria') or w.r.t the dual voronoi complex
+        # (KERN='bnd-dual').
+
+        ("bnds_kern", indx_t),
+
+        # MESH_DIMS - {default=+3} number of "topological" di-
+        # mensions to mesh. DIMS=K meshes K-dimensional featu-
+        # res, irrespective of the number of spatial dim.'s of
+        # the problem (i.e. if the geometry is 3-dimensional
+        # and DIMS=2 a surface mesh will be produced).
+
+        ("mesh_dims", indx_t),
+
+        # MESH_KERN - {default = 'delfront'} meshing kernal,
+        # choice of the standard Delaunay-refinement algorithm
+        # (KERN='delaunay') or the Frontal-Delaunay method
+        # (KERN='delfront').
+
+        ("mesh_kern", indx_t),
+
+        # MESH_ITER - {default = INF} max. number of mesh ref-
+        # inement iterations. Set ITER=N to see progress after
+        # N iterations.
+
+        ("mesh_iter", indx_t),
+
+        # MESH_TOP1 - {default=false} enforce 1-dim. topolog-
+        # ical constraints. 1-dim. edges are refined until all
+        # embedded nodes are "locally 1-manifold", i.e. nodes
+        # are either centred at topological "features", or lie
+        # on 1-manifold complexes.
+
+        ("mesh_top1", indx_t),
+
+        # MESH_TOP2 - {default=false} enforce 2-dim. topolog-
+        # ical constraints. 2-dim. trias are refined until all
+        # embedded nodes are "locally 2-manifold", i.e. nodes
+        # are either centred at topological "features", or lie
+        # on 2-manifold complexes.
+
+        ("mesh_top2", indx_t),
+
+        # MESH_RAD2 - {default = 1.05} max. radius-edge ratio
+        # for 2-tria elements. 2-trias are refined until the
+        # ratio of the element circumradii to min. edge length
+        # is less-than RAD2.
+
+        ("mesh_rad2", real_t),
+
+        # MESH_RAD3 - {default = 2.05} max. radius-edge ratio
+        # for 3-tria elements. 3-trias are refined until the
+        # ratio of the element circumradii to min. edge length
+        # is less-than RAD3.
+
+        ("mesh_rad3", real_t),
+
+        # MESH_SIZ1 - {default=4/3+eps} h(x)-based refinement
+        # multiplier for 1-dimensional elements. Edges are
+        # refined if they are locally larger than SIZ1 * h(x).
+
+        ("mesh_siz1", real_t),
+
+        # MESH_SIZ2 - {default=4/3+eps} h(x)-based refinement
+        # multiplier for 2-dimensional elements. Cells are
+        # refined if they are locally larger than SIZ2 * h(x).
+
+        ("mesh_siz2", real_t),
+
+        # MESH_SIZ3 - {default=4/3+eps} h(x)-based refinement
+        # multiplier for 3-dimensional elements. Cells are
+        # refined if they are locally larger than SIZ3 * h(x).
+
+        ("mesh_siz3", real_t),
+
+        # MESH_OFF2 - {default=0.90} radius-edge ratio target
+        # for insertion of "shape"-type offcentres for 2-tria
+        # elements. When refining an element II, offcentres
+        # are positioned to form a new "frontal" element JJ
+        # that satisfies JRAD <= OFF2.
+
+        ("mesh_off2", real_t),
+
+        # MESH_OFF3 - {default=1.10} radius-edge ratio target
+        # for insertion of "shape"-type offcentres for 3-tria
+        # elements. When refining an element II, offcentres
+        # are positioned to form a new "frontal" element JJ
+        # that satisfies JRAD <= OFF3.
+
+        ("mesh_off3", real_t),
+
+        # MESH_SNK2 - {default=0.20} inflation tolerance for
+        # insertion of "sink" offcentres for 2-tria elements.
+        # When refining an element II, "sinks" are positioned
+        # at the centre of the largest adj. circumball staisf-
+        # ying |JBAL-IBAL| < SNK2 * IRAD, where IRAD is the
+        # radius of the circumball, and [IBAL,JBAL] are the
+        # circumball centres.
+
+        ("mesh_snk2", real_t),
+
+        # MESH_SNK3 - {default=0.33} inflation tolerance for
+        # insertion of "sink" offcentres for 3-tria elements.
+        # When refining an element II, "sinks" are positioned
+        # at the centre of the largest adj. circumball staisf-
+        # ying |JBAL-IBAL| < SNK3 * IRAD, where IRAD is the
+        # radius of the circumball, and [IBAL,JBAL] are the
+        # circumball centres.
+
+        ("mesh_snk3", real_t),
+
+        # MESH_EPS1 - {default=0.33} max. surface-discretisa-
+        # tion error multiplier for 1-edge elements. 1-edge
+        # elements are refined until the surface-disc. error
+        # is less-than EPS1 * HFUN(X).
+
+        ("mesh_eps1", real_t),
+
+        # MESH_EPS2 - {default=0.33} max. surface-discretisa-
+        # tion error multiplier for 2-tria elements. 2-tria
+        # elements are refined until the surface-disc. error
+        # is less-than EPS2 * HFUN(X).
+
+        ("mesh_eps2", real_t),
+
+        # MESH_VOL3 - {default=0.00} min. volume-length ratio
+        # for 3-tria elements. 3-tria elements are refined
+        # until the volume-length ratio exceeds VOL3. Can be
+        # used to supress "sliver" elements.
+
+        ("mesh_vol3", real_t),
+
+        # OPTM_ITER - {default=16} max. number of mesh optim-
+        # isation iterations. Set ITER=N to see progress after
+        # N iterations.
+
+        ("optm_iter", indx_t),
+
+        # OPTM_QTOL - {default=1.E-04} tolerance on mesh cost
+        # function for convergence. Iteration on a given node
+        # is terminated if adjacent element cost-functions are
+        # improved by less than QTOL.
+
+        ("optm_qtol", real_t),
+
+        # OPTM_QLIM - {default=0.9375} threshold on mesh cost
+        # function above which gradient-based optimisation is
+        # attempted.
+
+        ("optm_qlim", real_t),
+
+        # OPTM_TRIA - {default= true} allow for optimisation
+        # of TRIA grid geometry.
+
+        ("optm_tria", indx_t),
+
+        # OPTM_DUAL - {default=false} allow for optimisation
+        # of DUAL grid geometry.
+
+        ("optm_dual", indx_t),
+
+        # OPTM_ZIP_ - {default= true} allow for "merge" oper-
+        # ations on sub-faces within the optimisation stages.
+
+        ("optm_zip_", indx_t),
+
+        # OPTM_DIV_ - {default= true} allow for "split" oper-
+        # ations on sub-faces within the optimisation stages.
+
+        ("optm_div_", indx_t)]

--- a/jigsawpy/jig_t.py
+++ b/jigsawpy/jig_t.py
@@ -1,283 +1,281 @@
 
 """ JIG_T: A set of user-defined options for JIGSAW.
- 
+
     REQUIRED fields:
     ---------------
- 
-    OPTS.JCFG_FILE - "JCFGNAME.JIG", a string containing the 
+
+    OPTS.JCFG_FILE - "JCFGNAME.JIG", a string containing the
         name of the cofig. file (will be created on output).
- 
-    OPTS.MESH_FILE - "MESHNAME.MSH", a string containing the 
+
+    OPTS.MESH_FILE - "MESHNAME.MSH", a string containing the
         name of the output file (will be created on output).
- 
+
     OPTIONAL fields (INIT):
     ----------------------
- 
-    OPTS.INIT_FILE - "INITNAME.MSH", a string containing the 
-        name of the initial distribution file (is required 
+
+    OPTS.INIT_FILE - "INITNAME.MSH", a string containing the
+        name of the initial distribution file (is required
         at input).
- 
+
     OPTS.INIT_NEAR - {default = 1.E-8} relative "zip" tol.
         applied when processing initial conditions. In cases
-        where "sharp-feature" detection is active, nodes in 
+        where "sharp-feature" detection is active, nodes in
         the initial set are zipped to their nearest feature
         node if the separation length is less than NEAR*SCAL
         where SCAL is the max. bounding-box dimension.
- 
+
     OPTIONAL fields (GEOM):
     ----------------------
- 
-    OPTS.GEOM_FILE - "GEOMNAME.MSH", a string containing the 
-        name of the geometry file (is required at input). 
+
+    OPTS.GEOM_FILE - "GEOMNAME.MSH", a string containing the
+        name of the geometry file (is required at input).
         See SAVEMSH for additional details regarding the cr-
         eation of *.MSH files.
- 
-    OPTS.GEOM_SEED - {default=8} number of "seed" vertices 
+
+    OPTS.GEOM_SEED - {default=8} number of "seed" vertices
         used to initialise mesh generation.
- 
-    OPTS.GEOM_FEAT - {default=false} attempt to auto-detect 
-        "sharp-features" in the input geometry. Features can 
-        lie adjacent to 1-dim. entities, (i.e. geometry 
-        "edges") and/or 2-dim. entities, (i.e. geometry 
+
+    OPTS.GEOM_FEAT - {default=false} attempt to auto-detect
+        "sharp-features" in the input geometry. Features can
+        lie adjacent to 1-dim. entities, (i.e. geometry
+        "edges") and/or 2-dim. entities, (i.e. geometry
         "faces") based on both geometrical and/or topologic-
-        al constraints. Geometrically, features are located 
-        between any neighbouring entities that subtend 
-        angles less than GEOM_ETAX degrees, where "X" is the 
+        al constraints. Geometrically, features are located
+        between any neighbouring entities that subtend
+        angles less than GEOM_ETAX degrees, where "X" is the
         (topological) dimension of the feature. Topological-
         ly, features are located at the apex of any non-man-
         ifold connections.
- 
-    OPTS.GEOM_ETA1 - {default=45deg} 1-dim. feature-angle, 
-        features are located between any neighbouring 
+
+    OPTS.GEOM_ETA1 - {default=45deg} 1-dim. feature-angle,
+        features are located between any neighbouring
         "edges" that subtend angles less than ETA1 deg.
- 
-    OPTS.GEOM_ETA2 - {default=45deg} 2-dim. feature angle, 
-        features are located between any neighbouring 
+
+    OPTS.GEOM_ETA2 - {default=45deg} 2-dim. feature angle,
+        features are located between any neighbouring
         "faces" that subtend angles less than ETA2 deg.
- 
+
     OPTIONAL fields (HFUN):
     ----------------------
- 
-    OPTS.HFUN_FILE - "HFUNNAME.MSH", a string containing the 
+
+    OPTS.HFUN_FILE - "HFUNNAME.MSH", a string containing the
         name of the mesh-size file (is required at input).
         The mesh-size function is specified as a general pi-
         ecewise linear function, defined at the vertices of
         an unstructured triangulation. See SAVEMSH for addi-
         tional details.
- 
-    OPTS.HFUN_SCAL - {default='relative'} scaling type for 
-        mesh-size fuction. HFUN_SCAL='relative' interprets 
-        mesh-size values as percentages of the (mean) length 
-        of the axis-aligned bounding-box (AABB) associated 
-        with the geometry. HFUN_SCAL='absolute' interprets 
+
+    OPTS.HFUN_SCAL - {default='relative'} scaling type for
+        mesh-size fuction. HFUN_SCAL='relative' interprets
+        mesh-size values as percentages of the (mean) length
+        of the axis-aligned bounding-box (AABB) associated
+        with the geometry. HFUN_SCAL='absolute' interprets
         mesh-size values as absolute measures.
- 
-    OPTS.HFUN_HMAX - {default=0.02} max. mesh-size function 
+
+    OPTS.HFUN_HMAX - {default=0.02} max. mesh-size function
         value. Interpreted based on SCAL setting.
- 
-    OPTS.HFUN_HMIN - {default=0.00} min. mesh-size function 
+
+    OPTS.HFUN_HMIN - {default=0.00} min. mesh-size function
         value. Interpreted based on SCAL setting.
- 
+
     OPTIONAL fields (MESH):
     ----------------------
- 
+
     OPTS.MESH_DIMS - {default=3} number of "topological" di-
         mensions to mesh. DIMS=K meshes K-dimensional featu-
-        res, irrespective of the number of spatial dim.'s of 
-        the problem (i.e. if the geometry is 3-dimensional 
+        res, irrespective of the number of spatial dim.'s of
+        the problem (i.e. if the geometry is 3-dimensional
         and DIMS=2 a surface mesh will be produced).
- 
+
     OPTS.MESH_KERN - {default='delfront'} meshing kernal,
-        choice of the standard Delaunay-refinement algorithm 
-        (KERN='delaunay') or the Frontal-Delaunay method 
+        choice of the standard Delaunay-refinement algorithm
+        (KERN='delaunay') or the Frontal-Delaunay method
         (KERN='delfront').
- 
+
     OPTS.MESH_ITER - {default=+INF} max. number of mesh ref-
-        inement iterations. Set ITER=N to see progress after 
-        N iterations. 
- 
+        inement iterations. Set ITER=N to see progress after
+        N iterations.
+
     OPTS.MESH_TOP1 - {default=false} enforce 1-dim. topolog-
-        ical constraints. 1-dim. edges are refined until all 
-        embedded nodes are "locally 1-manifold", i.e. nodes 
-        are either centred at topological "features", or lie 
+        ical constraints. 1-dim. edges are refined until all
+        embedded nodes are "locally 1-manifold", i.e. nodes
+        are either centred at topological "features", or lie
         on 1-manifold complexes.
- 
+
     OPTS.MESH_TOP2 - {default=false} enforce 2-dim. topolog-
-        ical constraints. 2-dim. trias are refined until all 
-        embedded nodes are "locally 2-manifold", i.e. nodes 
-        are either centred at topological "features", or lie 
+        ical constraints. 2-dim. trias are refined until all
+        embedded nodes are "locally 2-manifold", i.e. nodes
+        are either centred at topological "features", or lie
         on 2-manifold complexes.
- 
-    OPTS.MESH_RAD2 - {default=1.05} max. radius-edge ratio 
-        for 2-tria elements. 2-trias are refined until the 
-        ratio of the element circumradii to min. edge length 
+
+    OPTS.MESH_RAD2 - {default=1.05} max. radius-edge ratio
+        for 2-tria elements. 2-trias are refined until the
+        ratio of the element circumradii to min. edge length
         is less-than RAD2.
- 
-    OPTS.MESH_RAD3 - {default=2.05} max. radius-edge ratio 
-        for 3-tria elements. 3-trias are refined until the 
-        ratio of the element circumradii to min. edge length 
+
+    OPTS.MESH_RAD3 - {default=2.05} max. radius-edge ratio
+        for 3-tria elements. 3-trias are refined until the
+        ratio of the element circumradii to min. edge length
         is less-than RAD3.
- 
+
     OPTS.MESH_OFF2 - {default=0.90} radius-edge ratio target
         for insertion of "shape"-type offcentres for 2-tria
         elements. When refining an element II, offcentres
-        are positioned to form a new "frontal" element JJ 
+        are positioned to form a new "frontal" element JJ
         that satisfies JRAD <= OFF2.
- 
+
     OPTS.MESH_OFF3 - {default=1.10} radius-edge ratio target
         for insertion of "shape"-type offcentres for 3-tria
         elements. When refining an element II, offcentres
-        are positioned to form a new "frontal" element JJ 
+        are positioned to form a new "frontal" element JJ
         that satisfies JRAD <= OFF3.
- 
+
     OPTS.MESH_SNK2 - {default=0.20} inflation tolerance for
         insertion of "sink" offcentres for 2-tria elements.
         When refining an element II, "sinks" are positioned
         at the centre of the largest adj. circumball staisf-
-        ying |JBAL-IBAL| < SNK2 * IRAD, where IRAD is the 
-        radius of the circumball, and [IBAL,JBAL] are the 
+        ying |JBAL-IBAL| < SNK2 * IRAD, where IRAD is the
+        radius of the circumball, and [IBAL,JBAL] are the
         circumball centres.
- 
+
     OPTS.MESH_SNK3 - {default=0.33} inflation tolerance for
         insertion of "sink" offcentres for 3-tria elements.
         When refining an element II, "sinks" are positioned
         at the centre of the largest adj. circumball staisf-
-        ying |JBAL-IBAL| < SNK3 * IRAD, where IRAD is the 
-        radius of the circumball, and [IBAL,JBAL] are the 
+        ying |JBAL-IBAL| < SNK3 * IRAD, where IRAD is the
+        radius of the circumball, and [IBAL,JBAL] are the
         circumball centres.
- 
+
     OPTS.MESH_EPS1 - {default=0.33} max. surface-discretisa-
-        tion error multiplier for 1-edge elements. 1-edge 
-        elements are refined until the surface-disc. error 
+        tion error multiplier for 1-edge elements. 1-edge
+        elements are refined until the surface-disc. error
         is less-than EPS1 * HFUN(X).
- 
+
     OPTS.MESH_EPS2 - {default=0.33} max. surface-discretisa-
-        tion error multiplier for 2-tria elements. 2-tria 
-        elements are refined until the surface-disc. error 
+        tion error multiplier for 2-tria elements. 2-tria
+        elements are refined until the surface-disc. error
         is less-than EPS2 * HFUN(X).
- 
-    OPTS.MESH_VOL3 - {default=0.00} min. volume-length ratio 
-        for 3-tria elements. 3-tria elements are refined 
-        until the volume-length ratio exceeds VOL3. Can be 
+
+    OPTS.MESH_VOL3 - {default=0.00} min. volume-length ratio
+        for 3-tria elements. 3-tria elements are refined
+        until the volume-length ratio exceeds VOL3. Can be
         used to supress "sliver" elements.
- 
+
     OPTIONAL fields (OPTM):
     ----------------------
- 
+
     OPTS.OPTM_ITER - {default=16} max. number of mesh optim-
-        isation iterations. Set ITER=N to see progress after 
-        N iterations. 
- 
+        isation iterations. Set ITER=N to see progress after
+        N iterations.
+
     OPTS.OPTM_QTOL - {default=1.E-04} tolerance on mesh cost
         function for convergence. Iteration on a given node
         is terminated if adjacent element cost-functions are
         improved by less than QTOL.
- 
+
     OPTS.OPTM_QLIM - {default=0.9375} threshold on mesh cost
         function above which gradient-based optimisation is
         attempted.
- 
+
     OPTS.OPTM_TRIA - {default= true} allow for optimisation
         of TRIA grid geometry.
- 
+
     OPTS.OPTM_DUAL - {default=false} allow for optimisation
         of DUAL grid geometry.
- 
+
     OPTS.OPTM_ZIP_ - {default= true} allow for "merge" oper-
         ations on sub-face topology.
- 
+
     OPTS.OPTM_DIV_ - {default= true} allow for "split" oper-
         ations on sub-face topology.
- 
+
     OPTIONAL fields (MISC):
     ----------------------
- 
+
     OPTS.VERBOSITY - {default=0} verbosity of log-file gene-
         rated by JIGSAW. Set VERBOSITY >= 1 for more output.
- 
+
     See also MSH_t
- 
+
 
     --------------------------------------------------------
     """
 
+
 class jigsaw_jig_t:
     def __init__(self):
-    
-    #------------------------------------------ MISC options
+
+        # ------------------------------------------ MISC options
         self.verbosity = None
-        
+
         self.jcfg_file = None
-        
+
         self.tria_file = None
         self.bnds_file = None
-        
-    #------------------------------------------ INIT options
+
+    # ------------------------------------------ INIT options
         self.init_file = None
         self.init_near = None
-        
-    #------------------------------------------ GEOM options
+
+    # ------------------------------------------ GEOM options
         self.geom_file = None
-        
+
         self.geom_seed = None
-        
+
         self.geom_feat = None
-        
+
         self.geom_phi1 = None
         self.geom_phi2 = None
-        
+
         self.geom_eta1 = None
         self.geom_eta2 = None
-        
-    #------------------------------------------ HFUN options
-        self.hfun_file = None        
-        
+
+    # ------------------------------------------ HFUN options
+        self.hfun_file = None
+
         self.hfun_scal = None
-        
+
         self.hfun_hmax = None
         self.hfun_hmin = None
-        
-    #------------------------------------------ MESH options
+
+    # ------------------------------------------ MESH options
         self.mesh_file = None
-        
+
         self.mesh_kern = None
         self.bnds_kern = None
-        
+
         self.mesh_iter = None
-        
+
         self.mesh_dims = None
-        
+
         self.mesh_top1 = None
         self.mesh_top2 = None
-        
+
         self.mesh_siz1 = None
         self.mesh_siz2 = None
         self.mesh_siz3 = None
-        
+
         self.mesh_eps1 = None
         self.mesh_eps2 = None
-        
+
         self.mesh_rad2 = None
         self.mesh_rad3 = None
-    
+
         self.mesh_off2 = None
         self.mesh_off3 = None
-        
+
         self.mesh_snk2 = None
         self.mesh_snk3 = None
-        
+
         self.mesh_vol3 = None
-        
-    #------------------------------------------ OPTM options
-        self.optm_iter = None        
-        
+
+    # ------------------------------------------ OPTM options
+        self.optm_iter = None
+
         self.optm_qtol = None
         self.optm_qlim = None
-        
+
         self.optm_zip_ = None
         self.optm_div_ = None
         self.optm_tria = None
         self.optm_dual = None
-
-
-

--- a/jigsawpy/jigsaw.py
+++ b/jigsawpy/jigsaw.py
@@ -1,6 +1,7 @@
 
 import subprocess
-import os,inspect
+import os
+import inspect
 import shutil
 
 from pathlib import Path
@@ -11,7 +12,8 @@ from jigsawpy.msh_t import jigsaw_msh_t
 from jigsawpy.loadmsh import loadmsh
 from jigsawpy.savejig import savejig
 
-def jigsaw(opts,mesh=None):
+
+def jigsaw(opts, mesh=None):
     """
     JIGSAW cmd-line interface to JIGSAW.
 
@@ -26,54 +28,55 @@ def jigsaw(opts,mesh=None):
     """
     jexename = Path()
 
-    if (not isinstance(opts,jigsaw_jig_t)):
+    if (not isinstance(opts, jigsaw_jig_t)):
         raise Exception("Incorrect type: OPTS.")
 
-    if ((mesh is not None) and \
-        not isinstance(mesh,jigsaw_msh_t)):
+    if ((mesh is not None) and
+            not isinstance(mesh, jigsaw_msh_t)):
         raise Exception("Incorrect type: MESH.")
 
-    savejig(opts.jcfg_file,opts)
+    savejig(opts.jcfg_file, opts)
 
     if (jexename == Path()):
-#---------------------------- set-up path for "local" binary
+        # ---------------------------- set-up path for "local" binary
 
-    #   stackoverflow.com/questions/2632199/
-    #       how-do-i-get-the-
-    #       path-of-the-current-executed-file-in-python
+        #   stackoverflow.com/questions/2632199/
+        #       how-do-i-get-the-
+        #       path-of-the-current-executed-file-in-python
         filename = \
-            inspect.getsourcefile(lambda:0)
+            inspect.getsourcefile(lambda: 0)
 
         filepath = \
             Path(filename).resolve().parent
 
-        if   (os.name ==    "nt"):
-            jexename  = \
-                filepath/"_bin"/"jigsaw.exe"
+        if (os.name == "nt"):
+            jexename = \
+                filepath / "_bin" / "jigsaw.exe"
 
         elif (os.name == "posix"):
-            jexename  = \
-                filepath/"_bin"/"jigsaw"
+            jexename = \
+                filepath / "_bin" / "jigsaw"
 
         else:
-            jexename  = Path ()
+            jexename = Path()
 
         if (not jexename.is_file()):
-            jexename  = Path ()
+            jexename = Path()
 
     if (jexename == Path()):
-#---------------------------- search machine path for binary
-        jexescan = shutil.which("jigsaw")        
+        # ---------------------------- search machine path for binary
+        jexescan = shutil.which("jigsaw")
 
-        if (jexescan is not None):        
-            jexename  = Path ( jexescan )
+        if (jexescan is not None):
+            jexename = Path(jexescan)
 
     if (jexename != Path()):
-#---------------------------- call JIGSAW and capture output
-        subprocess.run( \
-            [str(jexename),opts.jcfg_file], check = True)
+        # ---------------------------- call JIGSAW and capture output
+        subprocess.run(
+            [str(jexename), opts.jcfg_file], check=True)
 
-        if mesh is not None: loadmsh(opts.mesh_file,mesh)
+        if mesh is not None:
+            loadmsh(opts.mesh_file, mesh)
 
     else:
 
@@ -82,7 +85,7 @@ def jigsaw(opts,mesh=None):
     return
 
 
-def tripod(opts,tria=None):
+def tripod(opts, tria=None):
     """
     TRIPOD cmd-line interface to TRIPOD.
 
@@ -97,60 +100,58 @@ def tripod(opts,tria=None):
     """
     jexename = Path()
 
-    if (not isinstance(opts,jigsaw_jig_t)):
+    if (not isinstance(opts, jigsaw_jig_t)):
         raise Exception("Incorrect type: OPTS.")
 
-    if ((tria is not None) and \
-        not isinstance(tria,jigsaw_msh_t)):
+    if ((tria is not None) and
+            not isinstance(tria, jigsaw_msh_t)):
         raise Exception("Incorrect type: TRIA.")
 
-    savejig(opts.jcfg_file,opts)
+    savejig(opts.jcfg_file, opts)
 
     if (jexename == Path()):
-#---------------------------- set-up path for "local" binary
-        
-    #   stackoverflow.com/questions/2632199/
-    #       how-do-i-get-the-
-    #       path-of-the-current-executed-file-in-python
+        # ---------------------------- set-up path for "local" binary
+
+        #   stackoverflow.com/questions/2632199/
+        #       how-do-i-get-the-
+        #       path-of-the-current-executed-file-in-python
         filename = \
-            inspect.getsourcefile(lambda:0)
+            inspect.getsourcefile(lambda: 0)
 
         filepath = \
             Path(filename).resolve().parent
 
-        if   (os.name ==    "nt"):
-            jexename  = \
-                filepath/"_bin"/"tripod.exe"
+        if (os.name == "nt"):
+            jexename = \
+                filepath / "_bin" / "tripod.exe"
 
         elif (os.name == "posix"):
-            jexename  = \
-                filepath/"_bin"/"tripod"
+            jexename = \
+                filepath / "_bin" / "tripod"
 
         else:
-            jexename  = Path ()
+            jexename = Path()
 
         if (not jexename.is_file()):
-            jexename  = Path ()
+            jexename = Path()
 
     if (jexename == Path()):
-#---------------------------- search machine path for binary
-        jexescan = shutil.which("tripod")        
+        # ---------------------------- search machine path for binary
+        jexescan = shutil.which("tripod")
 
-        if (jexescan is not None):        
-            jexename  = Path ( jexescan )
+        if (jexescan is not None):
+            jexename = Path(jexescan)
 
     if (jexename != Path()):
-#---------------------------- call JIGSAW and capture output
-        subprocess.run( \
-            [str(jexename),opts.jcfg_file], check = True)
+        # ---------------------------- call JIGSAW and capture output
+        subprocess.run(
+            [str(jexename), opts.jcfg_file], check=True)
 
-        if tria is not None: loadmsh(opts.mesh_file,tria)
+        if tria is not None:
+            loadmsh(opts.mesh_file, tria)
 
     else:
 
         raise Exception("JIGSAW's executable not found!")
 
     return
-
-
-

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -1,7 +1,8 @@
 
 import ctypes as ct
-import numpy  as np
-import os, inspect
+import numpy as np
+import os
+import inspect
 
 from pathlib import Path
 
@@ -19,52 +20,51 @@ from jigsawpy.jig_l import libsaw_jig_t
 from jigsawpy.certify import certify
 
 from jigsawpy.def_t import jigsaw_def_t
-from jigsawpy.jig_t import jigsaw_jig_t
 from jigsawpy.msh_t import jigsaw_msh_t
 
-#---------------------------- Try to find/load JIGSAW's API.
+# ---------------------------- Try to find/load JIGSAW's API.
 
 jlibname = Path()
 
 if (jlibname == Path()):
-#---------------------------- set-up path for "local" binary
+    # ---------------------------- set-up path for "local" binary
 
-#   stackoverflow.com/questions/2632199/
-#       how-do-i-get-the-
-#           path-of-the-current-executed-file-in-python
+    #   stackoverflow.com/questions/2632199/
+    #       how-do-i-get-the-
+    #           path-of-the-current-executed-file-in-python
     filename = \
-        inspect.getsourcefile(lambda:None)
+        inspect.getsourcefile(lambda: None)
 
     filepath = \
         (Path(filename).resolve()).parent
 
-    if   (os.name ==    "nt"):
-        jlibname  = \
-            filepath/"_lib"/  "jigsaw.dll"
+    if (os.name == "nt"):
+        jlibname = \
+            filepath / "_lib" / "jigsaw.dll"
 
     elif (os.name == "posix"):
-        jlibname  = \
-            filepath/"_lib"/"libjigsaw.so"
+        jlibname = \
+            filepath / "_lib" / "libjigsaw.so"
 
     else:
-        jlibname  = Path ()
+        jlibname = Path()
 
     if (not jlibname.is_file()):
-        jlibname  = Path ()
+        jlibname = Path()
 
 if (jlibname == Path()):
-#---------------------------- search machine path for binary
-    if   (os.name ==    "nt"):
-        jlibname  = Path (    "jigsaw.dll" )
+    # ---------------------------- search machine path for binary
+    if (os.name == "nt"):
+        jlibname = Path("jigsaw.dll")
 
     elif (os.name == "posix"):
-        jlibname  = Path (  "libjigsaw.so" )
+        jlibname = Path("libjigsaw.so")
 
     else:
-        jlibname  = Path ()
+        jlibname = Path()
 
 if (jlibname != Path()):
-#---------------------------- load jigsaw library via ctypes
+    # ---------------------------- load jigsaw library via ctypes
     jlib = ct.cdll.LoadLibrary(str(jlibname))
 
    #print( jlibname )
@@ -73,206 +73,207 @@ else:
     raise Exception("JIGSAW's lib not found")
 
 
-def put_jig_t(jigt,jigl):
+def put_jig_t(jigt, jigl):
     """
     PUT-JIG_t: Assign data from python-to-ctypes objects.
 
     """
-    if (jigt is None): return
+    if (jigt is None):
+        return
 
-    #--------------------------------- assign MISC user-opt.
-    if (isinstance(jigt.verbosity,int  )):
+    # --------------------------------- assign MISC user-opt.
+    if (isinstance(jigt.verbosity, int)):
         jigl.verbosity = indx_t(jigt.verbosity)
     elif (jigt.verbosity is not None):
         raise Exception("VERBOSITY type")
 
-    #--------------------------------- assign GEOM user-opt.
-    if (isinstance(jigt.geom_seed,int  )):
+    # --------------------------------- assign GEOM user-opt.
+    if (isinstance(jigt.geom_seed, int)):
         jigl.geom_seed = indx_t(jigt.geom_seed)
     elif (jigt.geom_seed is not None):
         raise Exception("GEOM-SEED type")
 
-    if (isinstance(jigt.geom_feat,bool )):
+    if (isinstance(jigt.geom_feat, bool)):
         jigl.geom_feat = indx_t(jigt.geom_feat)
     elif (jigt.geom_feat is not None):
         raise Exception("GEOM-FEAT type")
 
-    if (isinstance(jigt.geom_eta1,float)):
+    if (isinstance(jigt.geom_eta1, float)):
         jigl.geom_eta1 = real_t(jigt.geom_eta1)
     elif (jigt.geom_eta1 is not None):
         raise Exception("GEOM-ETA1 type")
 
-    if (isinstance(jigt.geom_eta2,float)):
+    if (isinstance(jigt.geom_eta2, float)):
         jigl.geom_eta2 = real_t(jigt.geom_eta2)
     elif (jigt.geom_eta2 is not None):
         raise Exception("GEOM-ETA2 type")
 
-    #--------------------------------- assign INIT user-opt.
-    if (isinstance(jigt.init_near,float)):
+    # --------------------------------- assign INIT user-opt.
+    if (isinstance(jigt.init_near, float)):
         jigl.init_near = real_t(jigt.init_near)
     elif (jigt.init_near is not None):
         raise Exception("INIT-NEAR type")
 
-    #--------------------------------- assign HFUN user-opt.
-    if (isinstance(jigt.hfun_scal,str  )):
-        if (jigt.hfun_scal.lower()=="absolute"):
+    # --------------------------------- assign HFUN user-opt.
+    if (isinstance(jigt.hfun_scal, str)):
+        if (jigt.hfun_scal.lower() == "absolute"):
             jigl.hfun_scal = \
-        jigsaw_def_t.JIGSAW_HFUN_ABSOLUTE
+                jigsaw_def_t.JIGSAW_HFUN_ABSOLUTE
 
-        if (jigt.hfun_scal.lower()=="relative"):
+        if (jigt.hfun_scal.lower() == "relative"):
             jigl.hfun_scal = \
-        jigsaw_def_t.JIGSAW_HFUN_RELATIVE
+                jigsaw_def_t.JIGSAW_HFUN_RELATIVE
 
     elif (jigt.hfun_scal is not None):
         raise Exception("HFUN-SCAL type")
 
-    if (isinstance(jigt.hfun_hmax,float)):
+    if (isinstance(jigt.hfun_hmax, float)):
         jigl.hfun_hmax = real_t(jigt.hfun_hmax)
     elif (jigt.hfun_hmax is not None):
         raise Exception("HFUN-HMAX type")
 
-    if (isinstance(jigt.hfun_hmin,float)):
+    if (isinstance(jigt.hfun_hmin, float)):
         jigl.hfun_hmin = real_t(jigt.hfun_hmin)
     elif (jigt.hfun_hmin is not None):
         raise Exception("HFUN-HMIN type")
 
-    #--------------------------------- assign MESH user-opt.
-    if (isinstance(jigt.bnds_kern,str  )):
-        if (jigt.bnds_kern.lower()=="triacell"):
+    # --------------------------------- assign MESH user-opt.
+    if (isinstance(jigt.bnds_kern, str)):
+        if (jigt.bnds_kern.lower() == "triacell"):
             jigl.bnds_kern = \
-        jigsaw_def_t.JIGSAW_BNDS_TRIACELL
+                jigsaw_def_t.JIGSAW_BNDS_TRIACELL
 
-        if (jigt.bnds_kern.lower()=="dualcell"):
+        if (jigt.bnds_kern.lower() == "dualcell"):
             jigl.bnds_kern = \
-        jigsaw_def_t.JIGSAW_BNDS_DUALCELL
+                jigsaw_def_t.JIGSAW_BNDS_DUALCELL
 
     elif (jigt.bnds_kern is not None):
         raise Exception("BNDS-KERN type")
 
-    if (isinstance(jigt.mesh_dims,int  )):
+    if (isinstance(jigt.mesh_dims, int)):
         jigl.mesh_dims = indx_t(jigt.mesh_dims)
     elif (jigt.mesh_dims is not None):
         raise Exception("MESH-DIMS type")
 
-    if (isinstance(jigt.mesh_kern,str  )):
-        if (jigt.mesh_kern.lower()=="delfront"):
+    if (isinstance(jigt.mesh_kern, str)):
+        if (jigt.mesh_kern.lower() == "delfront"):
             jigl.mesh_kern = \
-        jigsaw_def_t.JIGSAW_KERN_DELFRONT
+                jigsaw_def_t.JIGSAW_KERN_DELFRONT
 
-        if (jigt.mesh_kern.lower()=="delaunay"):
+        if (jigt.mesh_kern.lower() == "delaunay"):
             jigl.mesh_kern = \
-        jigsaw_def_t.JIGSAW_KERN_DELAUNAY
+                jigsaw_def_t.JIGSAW_KERN_DELAUNAY
 
     elif (jigt.mesh_kern is not None):
         raise Exception("MESH-KERN type")
 
-    if (isinstance(jigt.mesh_iter,int  )):
+    if (isinstance(jigt.mesh_iter, int)):
         jigl.mesh_iter = indx_t(jigt.mesh_iter)
     elif (jigt.mesh_iter is not None):
         raise Exception("MESH-ITER type")
 
-    if (isinstance(jigt.mesh_top1,bool )):
+    if (isinstance(jigt.mesh_top1, bool)):
         jigl.mesh_top1 = indx_t(jigt.mesh_top1)
     elif (jigt.mesh_top1 is not None):
         raise Exception("MESH-TOP1 type")
 
-    if (isinstance(jigt.mesh_top2,bool )):
+    if (isinstance(jigt.mesh_top2, bool)):
         jigl.mesh_top2 = indx_t(jigt.mesh_top2)
     elif (jigt.mesh_top2 is not None):
         raise Exception("MESH-TOP2 type")
 
-    if (isinstance(jigt.mesh_rad2,float)):
+    if (isinstance(jigt.mesh_rad2, float)):
         jigl.mesh_rad2 = real_t(jigt.mesh_rad2)
     elif (jigt.mesh_rad2 is not None):
         raise Exception("MESH-RAD2 type")
 
-    if (isinstance(jigt.mesh_rad3,float)):
+    if (isinstance(jigt.mesh_rad3, float)):
         jigl.mesh_rad3 = real_t(jigt.mesh_rad3)
     elif (jigt.mesh_rad3 is not None):
         raise Exception("MESH-RAD3 type")
 
-    if (isinstance(jigt.mesh_siz1,float)):
+    if (isinstance(jigt.mesh_siz1, float)):
         jigl.mesh_siz1 = real_t(jigt.mesh_siz1)
     elif (jigt.mesh_siz1 is not None):
         raise Exception("MESH-SIZ1 type")
 
-    if (isinstance(jigt.mesh_siz2,float)):
+    if (isinstance(jigt.mesh_siz2, float)):
         jigl.mesh_siz2 = real_t(jigt.mesh_siz2)
     elif (jigt.mesh_siz2 is not None):
         raise Exception("MESH-SIZ2 type")
 
-    if (isinstance(jigt.mesh_siz3,float)):
+    if (isinstance(jigt.mesh_siz3, float)):
         jigl.mesh_siz3 = real_t(jigt.mesh_siz3)
     elif (jigt.mesh_siz3 is not None):
         raise Exception("MESH-SIZ3 type")
 
-    if (isinstance(jigt.mesh_off2,float)):
+    if (isinstance(jigt.mesh_off2, float)):
         jigl.mesh_off2 = real_t(jigt.mesh_off2)
     elif (jigt.mesh_off2 is not None):
         raise Exception("MESH-OFF2 type")
 
-    if (isinstance(jigt.mesh_off3,float)):
+    if (isinstance(jigt.mesh_off3, float)):
         jigl.mesh_off3 = real_t(jigt.mesh_off3)
     elif (jigt.mesh_off3 is not None):
         raise Exception("MESH-OFF3 type")
 
-    if (isinstance(jigt.mesh_snk2,float)):
+    if (isinstance(jigt.mesh_snk2, float)):
         jigl.mesh_snk2 = real_t(jigt.mesh_snk2)
     elif (jigt.mesh_snk2 is not None):
         raise Exception("MESH-SNK2 type")
 
-    if (isinstance(jigt.mesh_snk3,float)):
+    if (isinstance(jigt.mesh_snk3, float)):
         jigl.mesh_snk3 = real_t(jigt.mesh_snk3)
     elif (jigt.mesh_snk3 is not None):
         raise Exception("MESH-SNK3 type")
 
-    if (isinstance(jigt.mesh_eps1,float)):
+    if (isinstance(jigt.mesh_eps1, float)):
         jigl.mesh_eps1 = real_t(jigt.mesh_eps1)
     elif (jigt.mesh_eps1 is not None):
         raise Exception("MESH-EPS1 type")
 
-    if (isinstance(jigt.mesh_eps2,float)):
+    if (isinstance(jigt.mesh_eps2, float)):
         jigl.mesh_eps2 = real_t(jigt.mesh_eps2)
     elif (jigt.mesh_eps2 is not None):
         raise Exception("MESH-EPS2 type")
 
-    if (isinstance(jigt.mesh_vol3,float)):
+    if (isinstance(jigt.mesh_vol3, float)):
         jigl.mesh_vol3 = real_t(jigt.mesh_vol3)
     elif (jigt.mesh_vol3 is not None):
         raise Exception("MESH-VOL3 type")
 
-    #--------------------------------- assign OPTM user-opt.
-    if (isinstance(jigt.optm_iter,int  )):
+    # --------------------------------- assign OPTM user-opt.
+    if (isinstance(jigt.optm_iter, int)):
         jigl.optm_iter = indx_t(jigt.optm_iter)
     elif (jigt.optm_iter is not None):
         raise Exception("OPTM-ITER type")
 
-    if (isinstance(jigt.optm_qtol,float)):
+    if (isinstance(jigt.optm_qtol, float)):
         jigl.optm_qtol = real_t(jigt.optm_qtol)
     elif (jigt.optm_qtol is not None):
         raise Exception("OPTM-QTOL type")
 
-    if (isinstance(jigt.optm_qlim,float)):
+    if (isinstance(jigt.optm_qlim, float)):
         jigl.optm_qlim = real_t(jigt.optm_qlim)
     elif (jigt.optm_qlim is not None):
         raise Exception("OPTM-QLIM type")
 
-    if (isinstance(jigt.optm_tria,bool )):
+    if (isinstance(jigt.optm_tria, bool)):
         jigl.optm_tria = indx_t(jigt.optm_tria)
     elif (jigt.optm_tria is not None):
         raise Exception("OPTM-TRIA type")
 
-    if (isinstance(jigt.optm_dual,bool )):
+    if (isinstance(jigt.optm_dual, bool)):
         jigl.optm_dual = indx_t(jigt.optm_dual)
     elif (jigt.optm_dual is not None):
         raise Exception("OPTM-DUAL type")
 
-    if (isinstance(jigt.optm_zip_,bool )):
+    if (isinstance(jigt.optm_zip_, bool)):
         jigl.optm_zip_ = indx_t(jigt.optm_zip_)
     elif (jigt.optm_zip_ is not None):
         raise Exception("OPTM-ZIP_ type")
 
-    if (isinstance(jigt.optm_div_,bool )):
+    if (isinstance(jigt.optm_div_, bool)):
         jigl.optm_div_ = indx_t(jigt.optm_div_)
     elif (jigt.optm_div_ is not None):
         raise Exception("OPTM-DIV_ type")
@@ -280,166 +281,167 @@ def put_jig_t(jigt,jigl):
     return
 
 
-def put_ptr_t(data,kind):
-    
-    #--------------------------------- helper to assign ptrs
+def put_ptr_t(data, kind):
+
+    # --------------------------------- helper to assign ptrs
     return np.asfortranarray(
-        data).ctypes.data_as( ct.POINTER(kind))
+        data).ctypes.data_as(ct.POINTER(kind))
 
 
-def put_msh_t(msht,mshl):
+def put_msh_t(msht, mshl):
     """
     PUT-MSH_t: Assign ptrs from python-to-ctypes objects.
 
     """
-    if (msht is None): return
+    if (msht is None):
+        return
 
     certify(msht)
 
     if (msht.mshID is not None):
-    #--------------------------------- assign mshID variable
-        if (msht.mshID.lower() == \
-                        "euclidean-mesh"):
+        # --------------------------------- assign mshID variable
+        if (msht.mshID.lower() ==
+                "euclidean-mesh"):
             mshl.flags = \
                 jigsaw_def_t. \
-                    JIGSAW_EUCLIDEAN_MESH
-        
-        if (msht.mshID.lower() == \
-                        "euclidean-grid"):
-            mshl.flags = \
-                jigsaw_def_t. \
-                    JIGSAW_EUCLIDEAN_GRID
+                JIGSAW_EUCLIDEAN_MESH
 
-        if (msht.mshID.lower() == \
-                        "ellipsoid-mesh"):
+        if (msht.mshID.lower() ==
+                "euclidean-grid"):
             mshl.flags = \
                 jigsaw_def_t. \
-                    JIGSAW_ELLIPSOID_MESH
+                JIGSAW_EUCLIDEAN_GRID
 
-        if (msht.mshID.lower() == \
-                        "ellipsoid-grid"):
+        if (msht.mshID.lower() ==
+                "ellipsoid-mesh"):
             mshl.flags = \
                 jigsaw_def_t. \
-                    JIGSAW_ELLIPSOID_GRID
-        
-    if (msht.radii is not None and \
-        msht.radii.size != +0 ):
-    #--------------------------------- assign ptrs for RADII
+                JIGSAW_ELLIPSOID_MESH
+
+        if (msht.mshID.lower() ==
+                "ellipsoid-grid"):
+            mshl.flags = \
+                jigsaw_def_t. \
+                JIGSAW_ELLIPSOID_GRID
+
+    if (msht.radii is not None and
+            msht.radii.size != +0):
+        # --------------------------------- assign ptrs for RADII
         mshl.radii.size = msht.radii.size
         mshl.radii.data = \
             put_ptr_t(msht.radii, real_t)
 
-    if (msht.vert2 is not None and \
-        msht.vert2.size != +0 ):
-    #--------------------------------- assign ptrs for VERT2
+    if (msht.vert2 is not None and
+            msht.vert2.size != +0):
+        # --------------------------------- assign ptrs for VERT2
         mshl.vert2.size = msht.vert2.size
         mshl.vert2.data = \
-            put_ptr_t (
-               msht.vert2,libsaw_VERT2_t)
+            put_ptr_t(
+                msht.vert2, libsaw_VERT2_t)
 
-    if (msht.vert3 is not None and \
-        msht.vert3.size != +0 ):
-    #--------------------------------- assign ptrs for VERT3
+    if (msht.vert3 is not None and
+            msht.vert3.size != +0):
+        # --------------------------------- assign ptrs for VERT3
         mshl.vert3.size = msht.vert3.size
         mshl.vert3.data = \
-            put_ptr_t (
-               msht.vert3,libsaw_VERT3_t)
+            put_ptr_t(
+                msht.vert3, libsaw_VERT3_t)
 
-    if (msht.power is not None and \
-        msht.power.size != +0 ):
-    #--------------------------------- assign ptrs for POWER
+    if (msht.power is not None and
+            msht.power.size != +0):
+        # --------------------------------- assign ptrs for POWER
         mshl.power.size = msht.power.size
         mshl.power.data = \
             put_ptr_t(msht.power, real_t)
 
-    if (msht.edge2 is not None and \
-        msht.edge2.size != +0 ):
-    #--------------------------------- assign ptrs for EDGE2
+    if (msht.edge2 is not None and
+            msht.edge2.size != +0):
+        # --------------------------------- assign ptrs for EDGE2
         mshl.edge2.size = msht.edge2.size
         mshl.edge2.data = \
-            put_ptr_t (
-               msht.edge2,libsaw_EDGE2_t)
+            put_ptr_t(
+                msht.edge2, libsaw_EDGE2_t)
 
-    if (msht.tria3 is not None and \
-        msht.tria3.size != +0 ):
-    #--------------------------------- assign ptrs for TRIA3
+    if (msht.tria3 is not None and
+            msht.tria3.size != +0):
+        # --------------------------------- assign ptrs for TRIA3
         mshl.tria3.size = msht.tria3.size
         mshl.tria3.data = \
-            put_ptr_t (
-               msht.tria3,libsaw_TRIA3_t)
+            put_ptr_t(
+                msht.tria3, libsaw_TRIA3_t)
 
-    if (msht.quad4 is not None and \
-        msht.quad4.size != +0 ):
-    #--------------------------------- assign ptrs for QUAD4
+    if (msht.quad4 is not None and
+            msht.quad4.size != +0):
+        # --------------------------------- assign ptrs for QUAD4
         mshl.quad4.size = msht.quad4.size
         mshl.quad4.data = \
-            put_ptr_t (
-               msht.quad4,libsaw_QUAD4_t)
+            put_ptr_t(
+                msht.quad4, libsaw_QUAD4_t)
 
-    if (msht.tria4 is not None and \
-        msht.tria4.size != +0 ):
-    #--------------------------------- assign ptrs for TRIA4
+    if (msht.tria4 is not None and
+            msht.tria4.size != +0):
+        # --------------------------------- assign ptrs for TRIA4
         mshl.tria4.size = msht.tria4.size
         mshl.tria4.data = \
-            put_ptr_t (
-               msht.tria4,libsaw_TRIA4_t)
+            put_ptr_t(
+                msht.tria4, libsaw_TRIA4_t)
 
-    if (msht.hexa8 is not None and \
-        msht.hexa8.size != +0 ):
-    #--------------------------------- assign ptrs for HEXA8
+    if (msht.hexa8 is not None and
+            msht.hexa8.size != +0):
+        # --------------------------------- assign ptrs for HEXA8
         mshl.hexa8.size = msht.hexa8.size
         mshl.hexa8.data = \
-            put_ptr_t (
-               msht.hexa8,libsaw_HEXA8_t)
+            put_ptr_t(
+                msht.hexa8, libsaw_HEXA8_t)
 
-    if (msht.wedg6 is not None and \
-        msht.wedg6.size != +0 ):
-    #--------------------------------- assign ptrs for WEDG6
+    if (msht.wedg6 is not None and
+            msht.wedg6.size != +0):
+        # --------------------------------- assign ptrs for WEDG6
         mshl.wedg6.size = msht.wedg6.size
         mshl.wedg6.data = \
-            put_ptr_t (
-                msht.wedg6,libsaw_WEDG6_t)
+            put_ptr_t(
+                msht.wedg6, libsaw_WEDG6_t)
 
-    if (msht.pyra5 is not None and \
-        msht.pyra5.size != +0 ):
-    #--------------------------------- assign ptrs for PYRA5
+    if (msht.pyra5 is not None and
+            msht.pyra5.size != +0):
+        # --------------------------------- assign ptrs for PYRA5
         mshl.pyra5.size = msht.pyra5.size
         mshl.pyra5.data = \
-            put_ptr_t (
-                msht.pyra5,libsaw_PYRA5_t)
+            put_ptr_t(
+                msht.pyra5, libsaw_PYRA5_t)
 
-    if (msht.bound is not None and \
-        msht.bound.size != +0 ):
-    #--------------------------------- assign ptrs for BOUND
+    if (msht.bound is not None and
+            msht.bound.size != +0):
+        # --------------------------------- assign ptrs for BOUND
         mshl.bound.size = msht.bound.size
         mshl.bound.data = \
-            put_ptr_t (
-                msht.bound,libsaw_BOUND_t)
+            put_ptr_t(
+                msht.bound, libsaw_BOUND_t)
 
-    if (msht.xgrid is not None and \
-        msht.xgrid.size != +0 ):
-    #--------------------------------- assign ptrs for XGRID
+    if (msht.xgrid is not None and
+            msht.xgrid.size != +0):
+        # --------------------------------- assign ptrs for XGRID
         mshl.xgrid.size = msht.xgrid.size
         mshl.xgrid.data = \
             put_ptr_t(msht.xgrid, real_t)
 
-    if (msht.ygrid is not None and \
-        msht.ygrid.size != +0 ):
-    #--------------------------------- assign ptrs for YGRID
+    if (msht.ygrid is not None and
+            msht.ygrid.size != +0):
+        # --------------------------------- assign ptrs for YGRID
         mshl.ygrid.size = msht.ygrid.size
         mshl.ygrid.data = \
             put_ptr_t(msht.ygrid, real_t)
 
-    if (msht.zgrid is not None and \
-        msht.zgrid.size != +0 ):
-    #--------------------------------- assign ptrs for ZGRID
+    if (msht.zgrid is not None and
+            msht.zgrid.size != +0):
+        # --------------------------------- assign ptrs for ZGRID
         mshl.zgrid.size = msht.zgrid.size
         mshl.zgrid.data = \
             put_ptr_t(msht.zgrid, real_t)
 
-    if (msht.value is not None and \
-        msht.value.size != +0 ):
-    #--------------------------------- assign ptrs for VALUE
+    if (msht.value is not None and
+            msht.value.size != +0):
+        # --------------------------------- assign ptrs for VALUE
         mshl.value.size = msht.value.size
         mshl.value.data = \
             put_ptr_t(msht.value, real_t)
@@ -447,296 +449,296 @@ def put_msh_t(msht,mshl):
     return
 
 
-def get_msh_t(msht,mshl):
+def get_msh_t(msht, mshl):
     """
     GET-MSH_t: Copy buffer from python-to-ctypes objects.
 
     """
-    if (mshl.flags == \
-            jigsaw_def_t. \
-                JIGSAW_EUCLIDEAN_MESH):
-        
-        msht.mshID =  "euclidean-mesh"
-    
-    if (mshl.flags == \
-            jigsaw_def_t. \
-                JIGSAW_EUCLIDEAN_GRID):
-        
-        msht.mshID =  "euclidean-grid"
+    if (mshl.flags ==
+            jigsaw_def_t.
+            JIGSAW_EUCLIDEAN_MESH):
 
-    if (mshl.flags == \
-            jigsaw_def_t. \
-                JIGSAW_ELLIPSOID_MESH):
-        
-        msht.mshID =  "ellipsoid-mesh"
+        msht.mshID = "euclidean-mesh"
 
-    if (mshl.flags == \
-            jigsaw_def_t. \
-                JIGSAW_ELLIPSOID_GRID):
-        
-        msht.mshID =  "ellipsoid-grid"
+    if (mshl.flags ==
+            jigsaw_def_t.
+            JIGSAW_EUCLIDEAN_GRID):
+
+        msht.mshID = "euclidean-grid"
+
+    if (mshl.flags ==
+            jigsaw_def_t.
+            JIGSAW_ELLIPSOID_MESH):
+
+        msht.mshID = "ellipsoid-mesh"
+
+    if (mshl.flags ==
+            jigsaw_def_t.
+            JIGSAW_ELLIPSOID_GRID):
+
+        msht.mshID = "ellipsoid-grid"
 
     if (mshl.radii.size >= +1):
-    #--------------------------------- copy buffer for RADII
+        # --------------------------------- copy buffer for RADII
         nsrc = mshl.radii.size
         asrc = mshl.radii.data
 
         msht.radii = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.radii.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.radii) )
+            ct.byref(mshl.radii))
 
     if (mshl.vert2.size >= +1):
-    #--------------------------------- copy buffer for VERT2
+        # --------------------------------- copy buffer for VERT2
         nsrc = mshl.vert2.size
         asrc = mshl.vert2.data
 
         msht.vert2 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.VERT2_t)
+                              dtype=jigsaw_msh_t.VERT2_t)
 
         adst = msht.vert2.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_VERT2_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_VERT2_t)
+                   )
 
         jlib.jigsaw_free_vert2(
-           ct.byref(mshl.vert2) )
+            ct.byref(mshl.vert2))
 
     if (mshl.vert3.size >= +1):
-    #--------------------------------- copy buffer for VERT3
+        # --------------------------------- copy buffer for VERT3
         nsrc = mshl.vert3.size
         asrc = mshl.vert3.data
 
         msht.vert3 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.VERT3_t)
+                              dtype=jigsaw_msh_t.VERT3_t)
 
         adst = msht.vert3.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_VERT3_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_VERT3_t)
+                   )
 
         jlib.jigsaw_free_vert3(
-           ct.byref(mshl.vert3) )
+            ct.byref(mshl.vert3))
 
     if (mshl.power.size >= +1):
-    #--------------------------------- copy buffer for POWER
+        # --------------------------------- copy buffer for POWER
         nsrc = mshl.power.size
         asrc = mshl.power.data
 
         msht.power = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.power.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.power) )
+            ct.byref(mshl.power))
 
     if (mshl.edge2.size >= +1):
-    #--------------------------------- copy buffer for EDGE2
+        # --------------------------------- copy buffer for EDGE2
         nsrc = mshl.edge2.size
         asrc = mshl.edge2.data
 
         msht.edge2 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.EDGE2_t)
+                              dtype=jigsaw_msh_t.EDGE2_t)
 
         adst = msht.edge2.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_EDGE2_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_EDGE2_t)
+                   )
 
         jlib.jigsaw_free_edge2(
-           ct.byref(mshl.edge2) )
+            ct.byref(mshl.edge2))
 
     if (mshl.tria3.size >= +1):
-    #--------------------------------- copy buffer for TRIA3
+        # --------------------------------- copy buffer for TRIA3
         nsrc = mshl.tria3.size
         asrc = mshl.tria3.data
 
         msht.tria3 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.TRIA3_t)
+                              dtype=jigsaw_msh_t.TRIA3_t)
 
         adst = msht.tria3.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_TRIA3_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_TRIA3_t)
+                   )
 
         jlib.jigsaw_free_tria3(
-           ct.byref(mshl.tria3) )
+            ct.byref(mshl.tria3))
 
     if (mshl.quad4.size >= +1):
-    #--------------------------------- copy buffer for QUAD4
+        # --------------------------------- copy buffer for QUAD4
         nsrc = mshl.quad4.size
         asrc = mshl.quad4.data
 
         msht.quad4 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.QUAD4_t)
+                              dtype=jigsaw_msh_t.QUAD4_t)
 
         adst = msht.quad4.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_QUAD4_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_QUAD4_t)
+                   )
 
         jlib.jigsaw_free_quad4(
-           ct.byref(mshl.quad4) )
+            ct.byref(mshl.quad4))
 
     if (mshl.tria4.size >= +1):
-    #--------------------------------- copy buffer for TRIA4
+        # --------------------------------- copy buffer for TRIA4
         nsrc = mshl.tria4.size
         asrc = mshl.tria4.data
 
         msht.tria4 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.TRIA4_t)
+                              dtype=jigsaw_msh_t.TRIA4_t)
 
         adst = msht.tria4.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_TRIA4_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_TRIA4_t)
+                   )
 
         jlib.jigsaw_free_tria4(
-           ct.byref(mshl.tria4) )
+            ct.byref(mshl.tria4))
 
     if (mshl.hexa8.size >= +1):
-    #--------------------------------- copy buffer for HEXA8
+        # --------------------------------- copy buffer for HEXA8
         nsrc = mshl.hexa8.size
         asrc = mshl.hexa8.data
 
         msht.hexa8 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.HEXA8_t)
+                              dtype=jigsaw_msh_t.HEXA8_t)
 
         adst = msht.hexa8.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_HEXA8_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_HEXA8_t)
+                   )
 
         jlib.jigsaw_free_hexa8(
-           ct.byref(mshl.hexa8) )
+            ct.byref(mshl.hexa8))
 
     if (mshl.wedg6.size >= +1):
-    #--------------------------------- copy buffer for WEDG6
+        # --------------------------------- copy buffer for WEDG6
         nsrc = mshl.wedg6.size
         asrc = mshl.wedg6.data
 
         msht.wedg6 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.WEDG6_t)
+                              dtype=jigsaw_msh_t.WEDG6_t)
 
         adst = msht.wedg6.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_WEDG6_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_WEDG6_t)
+                   )
 
         jlib.jigsaw_free_wedg6(
-           ct.byref(mshl.wedg6) )
+            ct.byref(mshl.wedg6))
 
     if (mshl.pyra5.size >= +1):
-    #--------------------------------- copy buffer for PYRA5
+        # --------------------------------- copy buffer for PYRA5
         nsrc = mshl.pyra5.size
         asrc = mshl.pyra5.data
 
         msht.pyra5 = np.empty(nsrc,
-           dtype=jigsaw_msh_t.PYRA5_t)
+                              dtype=jigsaw_msh_t.PYRA5_t)
 
         adst = msht.pyra5.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof(libsaw_PYRA5_t)
-                  )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(libsaw_PYRA5_t)
+                   )
 
         jlib.jigsaw_free_pyra5(
-           ct.byref(mshl.pyra5) )
+            ct.byref(mshl.pyra5))
 
     if (mshl.xgrid.size >= +1):
-    #--------------------------------- copy buffer for XGRID
+        # --------------------------------- copy buffer for XGRID
         nsrc = mshl.xgrid.size
         asrc = mshl.xgrid.data
 
         msht.xgrid = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.xgrid.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.xgrid) )
+            ct.byref(mshl.xgrid))
 
     if (mshl.ygrid.size >= +1):
-    #--------------------------------- copy buffer for YGRID
+        # --------------------------------- copy buffer for YGRID
         nsrc = mshl.ygrid.size
         asrc = mshl.ygrid.data
 
         msht.ygrid = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.ygrid.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.ygrid) )
+            ct.byref(mshl.ygrid))
 
     if (mshl.zgrid.size >= +1):
-    #--------------------------------- copy buffer for ZGRID
+        # --------------------------------- copy buffer for ZGRID
         nsrc = mshl.zgrid.size
         asrc = mshl.zgrid.data
 
         msht.zgrid = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.zgrid.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.zgrid) )
-        
+            ct.byref(mshl.zgrid))
+
     if (mshl.value.size >= +1):
-    #--------------------------------- copy buffer for VALUE
+        # --------------------------------- copy buffer for VALUE
         nsrc = mshl.value.size
         asrc = mshl.value.data
 
         msht.value = np.empty(nsrc,
-           dtype=jigsaw_msh_t.REALS_t)
+                              dtype=jigsaw_msh_t.REALS_t)
 
         adst = msht.value.ctypes.data
-        ct.memmove(adst,asrc,
-        nsrc*ct.sizeof (real_t) )
+        ct.memmove(adst, asrc,
+                   nsrc * ct.sizeof(real_t))
 
         jlib.jigsaw_free_reals(
-           ct.byref(mshl.value) )
+            ct.byref(mshl.value))
 
     return
 
 
-def jigsaw(opts,geom,mesh ,
+def jigsaw(opts, geom, mesh,
            init=None,
-           hfun=None) :
+           hfun=None):
     """
     JIGSAW API-lib. interface to JIGSAW.
- 
+
     JIGSAW(OPTS,GEOM,MESH,INIT=None,
                           HFUN=None)
- 
-    Call the JIGSAW mesh generator using the config. options 
+
+    Call the JIGSAW mesh generator using the config. options
     specified in the OPTS structure.
- 
+
     OPTS is a user-defined set of meshing options. See JIG_t
     for details.
- 
+
     """
 
-    #--------------------------------- set-up ctypes objects
+    # --------------------------------- set-up ctypes objects
 
     ojig = libsaw_jig_t()
 
-    jlib.jigsaw_init_jig_t(ct.byref(ojig))    
+    jlib.jigsaw_init_jig_t(ct.byref(ojig))
 
-    put_jig_t (opts,ojig)
+    put_jig_t(opts, ojig)
 
     gmsh = libsaw_msh_t()
     mmsh = libsaw_msh_t()
@@ -747,54 +749,56 @@ def jigsaw(opts,geom,mesh ,
     jlib.jigsaw_init_msh_t(ct.byref(mmsh))
     jlib.jigsaw_init_msh_t(ct.byref(imsh))
     jlib.jigsaw_init_msh_t(ct.byref(hmsh))
-    
-    put_msh_t (geom,gmsh)
-    put_msh_t (init,imsh)
-    put_msh_t (hfun,hmsh)
 
-    iptr = ct.byref(imsh) 
-    if init is None:iptr = 0
+    put_msh_t(geom, gmsh)
+    put_msh_t(init, imsh)
+    put_msh_t(hfun, hmsh)
 
-    hptr = ct.byref(hmsh) 
-    if hfun is None:hptr = 0
+    iptr = ct.byref(imsh)
+    if init is None:
+        iptr = 0
 
-    #--------------------------------- call to JIGSAW's lib.
+    hptr = ct.byref(hmsh)
+    if hfun is None:
+        hptr = 0
 
-    retv = jlib.jigsaw(ct.byref(ojig), \
-                       ct.byref(gmsh), \
-                       iptr, \
-                       hptr, \
+    # --------------------------------- call to JIGSAW's lib.
+
+    retv = jlib.jigsaw(ct.byref(ojig),
+                       ct.byref(gmsh),
+                       iptr,
+                       hptr,
                        ct.byref(mmsh))
 
-    #--------------------------------- copy buffers to MSH_t
+    # --------------------------------- copy buffers to MSH_t
 
-    get_msh_t (mesh,mmsh)
+    get_msh_t(mesh, mmsh)
 
     return
 
 
-def tripod(opts,init,tria ,
-           geom=None) :
+def tripod(opts, init, tria,
+           geom=None):
     """
     TRIPOD API-lib. interface to TRIPOD.
- 
+
     TRIPOD(OPTS,INIT,TRIA,GEOM=None)
- 
-    Call the TRIPOD tessellation util. using the config. opt 
-    specified in the OPTS structure. 
- 
+
+    Call the TRIPOD tessellation util. using the config. opt
+    specified in the OPTS structure.
+
     OPTS is a user-defined set of meshing options. See JIG_t
     for details.
- 
+
     """
 
-    #--------------------------------- set-up ctypes objects
-    
+    # --------------------------------- set-up ctypes objects
+
     ojig = libsaw_jig_t()
 
-    jlib.jigsaw_init_jig_t(ct.byref(ojig))    
+    jlib.jigsaw_init_jig_t(ct.byref(ojig))
 
-    put_jig_t (opts,ojig)
+    put_jig_t(opts, ojig)
 
     imsh = libsaw_msh_t()
     tmsh = libsaw_msh_t()
@@ -804,24 +808,22 @@ def tripod(opts,init,tria ,
     jlib.jigsaw_init_msh_t(ct.byref(tmsh))
     jlib.jigsaw_init_msh_t(ct.byref(gmsh))
 
-    put_msh_t (init,imsh)
-    put_msh_t (geom,gmsh)
+    put_msh_t(init, imsh)
+    put_msh_t(geom, gmsh)
 
-    gptr = ct.byref(gmsh) 
-    if geom is None:gptr = 0
+    gptr = ct.byref(gmsh)
+    if geom is None:
+        gptr = 0
 
-    #--------------------------------- call to JIGSAW's lib.
-    
-    retv = jlib.tripod(ct.byref(ojig), \
-                       ct.byref(imsh), \
-                       gptr, \
+    # --------------------------------- call to JIGSAW's lib.
+
+    retv = jlib.tripod(ct.byref(ojig),
+                       ct.byref(imsh),
+                       gptr,
                        ct.byref(tmsh))
 
-    #--------------------------------- copy buffers to MSH_t
+    # --------------------------------- copy buffers to MSH_t
 
-    get_msh_t (tria,tmsh)
+    get_msh_t(tria, tmsh)
 
     return
-
-
-

--- a/jigsawpy/loadjig.py
+++ b/jigsawpy/loadjig.py
@@ -1,11 +1,12 @@
 
 from pathlib import Path
-from jigsawpy.jig_t  import jigsaw_jig_t
+from jigsawpy.jig_t import jigsaw_jig_t
 
-def loadjig(name,opts):
+
+def loadjig(name, opts):
     """
     LOADJIG: load a JIG config. obj. from file.
-    
+
     LOADJIG(NAME,OPTS)
 
     OPTS is a user-defined set of meshing options. See JIG_t
@@ -16,104 +17,104 @@ def loadjig(name,opts):
 
     """
 
-    if (not isinstance(name,str)):
+    if (not isinstance(name, str)):
         raise Exception("Incorrect type: NAME.")
-        
-    if (not isinstance(opts,jigsaw_jig_t)):
+
+    if (not isinstance(opts, jigsaw_jig_t)):
         raise Exception("Incorrect type: OPTS.")
-    
+
     with Path(name).open("r") as file:
         while (True):
-        
-        #----------------------- get the next line from file    
-            line = file.readline ()
-            
+
+            # ----------------------- get the next line from file
+            line = file.readline()
+
             if (len(line) != +0):
 
-        #----------------------- parse next non-null section            
+                # ----------------------- parse next non-null section
                 if (line[0] == " "):
-                    continue                    
-  
+                    continue
+
                 ltag = line.split("=")
                 item = ltag[0].upper()
                 item = item.strip()
-                
-        #-------------------------------------- MISC options
+
+        # -------------------------------------- MISC options
                 if (item == "VERBOSITY"):
-                    opts.verbosity = int  (ltag[1])
-                    
+                    opts.verbosity = int(ltag[1])
+
                 if (item == "TRIA_FILE"):
                     opts.tria_file = ltag[1].strip()
-                    
+
                 if (item == "BNDS_FILE"):
                     opts.bnds_file = ltag[1].strip()
-                    
-        #-------------------------------------- INIT options
+
+        # -------------------------------------- INIT options
                 if (item == "INIT_FILE"):
                     opts.init_file = ltag[1].strip()
-        
+
                 if (item == "INIT_NEAR"):
                     opts.init_near = float(ltag[1])
 
-        #-------------------------------------- GEOM options
+        # -------------------------------------- GEOM options
                 if (item == "GEOM_FILE"):
                     opts.geom_file = ltag[1].strip()
-        
+
                 if (item == "GEOM_SEED"):
-                    opts.geom_seed = int  (ltag[1])
-                    
+                    opts.geom_seed = int(ltag[1])
+
                 if (item == "GEOM_FEAT"):
-                    opts.geom_feat = bool (ltag[1])
-       
+                    opts.geom_feat = bool(ltag[1])
+
                 if (item == "GEOM_PHI1"):
                     opts.geom_phi1 = float(ltag[1])
                 if (item == "GEOM_PHI2"):
                     opts.geom_phi2 = float(ltag[1])
-                    
+
                 if (item == "GEOM_ETA1"):
                     opts.geom_eta1 = float(ltag[1])
                 if (item == "GEOM_ETA2"):
                     opts.geom_eta2 = float(ltag[1])
-                    
-        #-------------------------------------- HFUN options
+
+        # -------------------------------------- HFUN options
                 if (item == "HFUN_FILE"):
                     opts.hfun_file = ltag[1].strip()
-        
+
                 if (item == "HFUN_SCAL"):
                     opts.hfun_scal = ltag[1].strip()
-        
+
                 if (item == "HFUN_HMAX"):
                     opts.hfun_hmax = float(ltag[1])
                 if (item == "HFUN_HMIN"):
                     opts.hfun_hmin = float(ltag[1])
-                    
-        #-------------------------------------- MESH options
+
+        # -------------------------------------- MESH options
                 if (item == "MESH_FILE"):
                     opts.mesh_file = ltag[1].strip()
-                    
+
                 if (item == "MESH_KERN"):
                     opts.mesh_kern = ltag[1].strip()
                 if (item == "BNDS_KERN"):
                     opts.bnds_kern = ltag[1].strip()
-        
+
                 if (item == "MESH_ITER"):
-                    opts.mesh_iter = int  (ltag[1])
-                    
+                    opts.mesh_iter = int(ltag[1])
+
                 if (item == "MESH_DIMS"):
-                    opts.mesh_dims = int  (ltag[1])
-                    
+                    opts.mesh_dims = int(ltag[1])
+
                 if (item == "MESH_TOP1"):
-                    opts.mesh_top1 = bool (ltag[1])
+                    opts.mesh_top1 = bool(ltag[1])
                 if (item == "MESH_TOP2"):
-                    opts.mesh_top2 = bool (ltag[1])
-        
+                    opts.mesh_top2 = bool(ltag[1])
+
                 if (item == "MESH_SIZ1"):
                     opts.mesh_siz1 = float(ltag[1])
                 if (item == "MESH_SIZ2"):
                     opts.mesh_siz2 = float(ltag[1])
                 if (item == "MESH_SIZ3"):
                     opts.mesh_siz3 = float(ltag[1])
-        
+
                 if (item == "MESH_EPS1"):
                     opts.mesh_eps1 = float(ltag[1])
                 if (item == "MESH_EPS2"):
@@ -123,12 +124,12 @@ def loadjig(name,opts):
                     opts.mesh_rad2 = float(ltag[1])
                 if (item == "MESH_RAD3"):
                     opts.mesh_rad3 = float(ltag[1])
-                    
+
                 if (item == "MESH_OFF2"):
                     opts.mesh_off2 = float(ltag[1])
                 if (item == "MESH_OFF3"):
                     opts.mesh_off3 = float(ltag[1])
-        
+
                 if (item == "MESH_SNK2"):
                     opts.mesh_snk2 = float(ltag[1])
                 if (item == "MESH_SNK3"):
@@ -136,30 +137,27 @@ def loadjig(name,opts):
 
                 if (item == "MESH_VOL3"):
                     opts.mesh_vol3 = float(ltag[1])
-                    
-        #-------------------------------------- OPTM options
+
+        # -------------------------------------- OPTM options
                 if (item == "OPTM_ITER"):
-                    opts.optm_iter = int  (ltag[1])
-                    
+                    opts.optm_iter = int(ltag[1])
+
                 if (item == "OPTM_QTOL"):
                     opts.optm_qtol = float(ltag[1])
                 if (item == "OPTM_QLIM"):
                     opts.optm_qlim = float(ltag[1])
-                    
+
                 if (item == "OPTM_ZIP_"):
-                    opts.optm_zip_ = bool (ltag[1])
+                    opts.optm_zip_ = bool(ltag[1])
                 if (item == "OPTM_DIV_"):
-                    opts.optm_div_ = bool (ltag[1])
+                    opts.optm_div_ = bool(ltag[1])
                 if (item == "OPTM_TRIA"):
-                    opts.optm_tria = bool (ltag[1])
+                    opts.optm_tria = bool(ltag[1])
                 if (item == "OPTM_DUAL"):
-                    opts.optm_dual = bool (ltag[1])
-            
+                    opts.optm_dual = bool(ltag[1])
+
             else:
-        #----------------------- reached end-of-file: done!!      
+                # ----------------------- reached end-of-file: done!!
                 break
 
     return
-    
-
-

--- a/jigsawpy/loadmsh.py
+++ b/jigsawpy/loadmsh.py
@@ -3,60 +3,61 @@ import numpy as np
 from pathlib import Path
 from jigsawpy.msh_t import jigsaw_msh_t
 
-def loadradii(mesh,file,ltag):
+
+def loadradii(mesh, file, ltag):
     """
     LOADRADII: load the RADII data segment from file.
-    
+
     """
     rtag = ltag[1].split(";")
 
-    mesh.radii = np.empty( \
-        +3,dtype=jigsaw_msh_t.REALS_t)
+    mesh.radii = np.empty(
+        +3, dtype=jigsaw_msh_t.REALS_t)
 
-    if   (len(rtag) == +1):    
+    if (len(rtag) == +1):
         mesh.radii[0] = float(rtag[0])
         mesh.radii[1] = float(rtag[0])
         mesh.radii[2] = float(rtag[0])
 
-    elif (len(rtag) == +3):    
+    elif (len(rtag) == +3):
         mesh.radii[0] = float(rtag[0])
         mesh.radii[1] = float(rtag[1])
         mesh.radii[2] = float(rtag[2])
 
     else:
-        raise Exception( \
-            "Invalid RADII data: "+ ltag)
+        raise Exception(
+            "Invalid RADII data: " + ltag)
 
     return
 
 
-def loadpoint(mesh,file,ltag):
+def loadpoint(mesh, file, ltag):
     """
     LOADPOINT: load the POINT data segment from file.
-    
+
     """
-    if   (mesh.ndims == +2):
-        loadvert2(mesh,file,ltag)
-    
+    if (mesh.ndims == +2):
+        loadvert2(mesh, file, ltag)
+
     elif (mesh.ndims == +3):
-        loadvert3(mesh,file,ltag)
+        loadvert3(mesh, file, ltag)
 
     else:
-        raise Exception( \
-            "Invalid NDIMS data: "+ ltag)
-    
+        raise Exception(
+            "Invalid NDIMS data: " + ltag)
+
     return
-    
-    
-def loadvert2(mesh,file,ltag):
+
+
+def loadvert2(mesh, file, ltag):
     """
     LOADVERT2: load the 2-dim. vertex pos. from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.vert2 = np.empty( \
+
+    mesh.vert2 = np.empty(
         lnum, dtype=jigsaw_msh_t.VERT2_t)
 
     vpts = mesh.vert2["coord"]
@@ -65,31 +66,31 @@ def loadvert2(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-       
+
         if (len(dtag) == +3):
-            vpts[next,0] = float(dtag[0])
-            vpts[next,1] = float(dtag[1])
-            
-            itag[next]   = int  (dtag[2])
+            vpts[next, 0] = float(dtag[0])
+            vpts[next, 1] = float(dtag[1])
+
+            itag[next] = int(dtag[2])
         else:
-            raise Exception( \
-            "Invalid POINT data: "+ data)
+            raise Exception(
+                "Invalid POINT data: " + data)
 
         lnum -= +1
         next += +1
-    
-    return
-    
 
-def loadvert3(mesh,file,ltag):
+    return
+
+
+def loadvert3(mesh, file, ltag):
     """
     LOADVERT3: load the 3-dim. vertex pos. from file.
 
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.vert3 = np.empty( \
+
+    mesh.vert3 = np.empty(
         lnum, dtype=jigsaw_msh_t.VERT3_t)
 
     vpts = mesh.vert3["coord"]
@@ -98,90 +99,90 @@ def loadvert3(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +4):
-            vpts[next,0] = float(dtag[0])
-            vpts[next,1] = float(dtag[1])
-            vpts[next,2] = float(dtag[2])
-            
-            itag[next]   = int  (dtag[3])
+            vpts[next, 0] = float(dtag[0])
+            vpts[next, 1] = float(dtag[1])
+            vpts[next, 2] = float(dtag[2])
+
+            itag[next] = int(dtag[3])
         else:
-            raise Exception( \
-            "Invalid POINT data: "+ data)
+            raise Exception(
+                "Invalid POINT data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadpower(mesh,file,ltag):
+def loadpower(mesh, file, ltag):
     """
     LOADPOWER: load the POWER data segment from file.
-    
+
     """
-    ptag = ltag[ 1].split(";")
+    ptag = ltag[1].split(";")
 
     lnum = int(ptag[0])
     pnum = int(ptag[1])
     next = +0
-    
-    mesh.power = np.empty( \
-       [lnum,pnum],dtype=jigsaw_msh_t.REALS_t)
 
-    vpwr = mesh.power[:,:]
-   
+    mesh.power = np.empty(
+        [lnum, pnum], dtype=jigsaw_msh_t.REALS_t)
+
+    vpwr = mesh.power[:, :]
+
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         for dpos in range(len(dtag)):
-            vpwr[next,dpos]= float(dtag[dpos])
-        
+            vpwr[next, dpos] = float(dtag[dpos])
+
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadvalue(mesh,file,ltag):
+def loadvalue(mesh, file, ltag):
     """
     LOADVALUE: load the VALUE data segment from file.
-    
+
     """
-    vtag = ltag[ 1].split(";")
+    vtag = ltag[1].split(";")
 
     lnum = int(vtag[0])
     vnum = int(vtag[1])
     next = +0
-    
-    mesh.value = np.empty( \
-       [lnum,vnum],dtype=jigsaw_msh_t.REALS_t)    
 
-    vals = mesh.value[:,:]
+    mesh.value = np.empty(
+        [lnum, vnum], dtype=jigsaw_msh_t.REALS_t)
+
+    vals = mesh.value[:, :]
 
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         for dpos in range(len(dtag)):
-            vals[next,dpos]= float(dtag[dpos])
-        
+            vals[next, dpos] = float(dtag[dpos])
+
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadedge2(mesh,file,ltag):
+def loadedge2(mesh, file, ltag):
     """
     LOADEDGE2: load the EDGE2 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
-    next = 0    
+    next = 0
 
-    mesh.edge2 = np.empty( \
+    mesh.edge2 = np.empty(
         lnum, dtype=jigsaw_msh_t.EDGE2_t)
 
     cell = mesh.edge2["index"]
@@ -191,30 +192,30 @@ def loadedge2(mesh,file,ltag):
         data = file.readline()
         dtag = data.split(";")
 
-        if (len(dtag) == +3):        
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            
-            itag[next]   = int  (dtag[2])
+        if (len(dtag) == +3):
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+
+            itag[next] = int(dtag[2])
         else:
-            raise Exception( \
-            "Invalid EDGE2 data: "+ data)
+            raise Exception(
+                "Invalid EDGE2 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
-        
-        
-def loadtria3(mesh,file,ltag):
+
+
+def loadtria3(mesh, file, ltag):
     """
     LOADTRIA3: load the TRIA3 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.tria3 = np.empty( \
+
+    mesh.tria3 = np.empty(
         lnum, dtype=jigsaw_msh_t.TRIA3_t)
 
     cell = mesh.tria3["index"]
@@ -223,32 +224,32 @@ def loadtria3(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +4):
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            
-            itag[next]   = int  (dtag[3])
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+
+            itag[next] = int(dtag[3])
         else:
-            raise Exception( \
-            "Invalid TRIA3 data: "+ data)
+            raise Exception(
+                "Invalid TRIA3 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
-        
-        
-def loadquad4(mesh,file,ltag):
+
+
+def loadquad4(mesh, file, ltag):
     """
     LOADUAD4: load the QUAD4 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.quad4 = np.empty( \
+
+    mesh.quad4 = np.empty(
         lnum, dtype=jigsaw_msh_t.QUAD4_t)
 
     cell = mesh.quad4["index"]
@@ -257,33 +258,33 @@ def loadquad4(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +5):
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            cell[next,3] = int  (dtag[3])
-            
-            itag[next]   = int  (dtag[4])
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+            cell[next, 3] = int(dtag[3])
+
+            itag[next] = int(dtag[4])
         else:
-            raise Exception( \
-            "Invalid QUAD4 data: "+ data)
+            raise Exception(
+                "Invalid QUAD4 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
-        
-        
-def loadtria4(mesh,file,ltag):
+
+
+def loadtria4(mesh, file, ltag):
     """
     LOADTRIA4: load the TRIA4 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.tria4 = np.empty( \
+
+    mesh.tria4 = np.empty(
         lnum, dtype=jigsaw_msh_t.TRIA4_t)
 
     cell = mesh.tria4["index"]
@@ -292,33 +293,33 @@ def loadtria4(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-    
-        if (len(dtag) == +5):     
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            cell[next,3] = int  (dtag[3])
-            
-            itag[next]   = int  (dtag[4])
+
+        if (len(dtag) == +5):
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+            cell[next, 3] = int(dtag[3])
+
+            itag[next] = int(dtag[4])
         else:
-            raise Exception( \
-            "Invalid TRIA4 data: "+ data)
+            raise Exception(
+                "Invalid TRIA4 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
-    
-    
-def loadhexa8(mesh,file,ltag):
+
+
+def loadhexa8(mesh, file, ltag):
     """
     LOADHEXA8: load the HEXA8 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.hexa8 = np.empty( \
+
+    mesh.hexa8 = np.empty(
         lnum, dtype=jigsaw_msh_t.HEXA8_t)
 
     cell = mesh.hexa8["index"]
@@ -327,37 +328,37 @@ def loadhexa8(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +9):
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            cell[next,3] = int  (dtag[3])
-            cell[next,4] = int  (dtag[4])
-            cell[next,5] = int  (dtag[5])
-            cell[next,6] = int  (dtag[6])
-            cell[next,7] = int  (dtag[7])
-            
-            itag[next]   = int  (dtag[8])
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+            cell[next, 3] = int(dtag[3])
+            cell[next, 4] = int(dtag[4])
+            cell[next, 5] = int(dtag[5])
+            cell[next, 6] = int(dtag[6])
+            cell[next, 7] = int(dtag[7])
+
+            itag[next] = int(dtag[8])
         else:
-            raise Exception( \
-            "Invalid HEXA8 data: "+ data)
+            raise Exception(
+                "Invalid HEXA8 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadpyra5(mesh,file,ltag):
+def loadpyra5(mesh, file, ltag):
     """
     LOADPYRA5: load the PYRA5 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.pyra5 = np.empty( \
+
+    mesh.pyra5 = np.empty(
         lnum, dtype=jigsaw_msh_t.PYRA5_t)
 
     cell = mesh.pyra5["index"]
@@ -366,34 +367,34 @@ def loadpyra5(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +6):
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            cell[next,3] = int  (dtag[3])
-            cell[next,4] = int  (dtag[4])
-            
-            itag[next]   = int  (dtag[5])
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+            cell[next, 3] = int(dtag[3])
+            cell[next, 4] = int(dtag[4])
+
+            itag[next] = int(dtag[5])
         else:
-            raise Exception( \
-            "Invalid PYRA5 data: "+ data)
+            raise Exception(
+                "Invalid PYRA5 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadwedg6(mesh,file,ltag):
+def loadwedg6(mesh, file, ltag):
     """
     LOADWEDG6: load the WEDG6 data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.wedg6 = np.empty( \
+
+    mesh.wedg6 = np.empty(
         lnum, dtype=jigsaw_msh_t.WEDG6_t)
 
     cell = mesh.wedg6["index"]
@@ -402,35 +403,35 @@ def loadwedg6(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-        
+
         if (len(dtag) == +7):
-            cell[next,0] = int  (dtag[0])
-            cell[next,1] = int  (dtag[1])
-            cell[next,2] = int  (dtag[2])
-            cell[next,3] = int  (dtag[3])
-            cell[next,4] = int  (dtag[4])
-            cell[next,5] = int  (dtag[5])
-            
-            itag[next]   = int  (dtag[6])
+            cell[next, 0] = int(dtag[0])
+            cell[next, 1] = int(dtag[1])
+            cell[next, 2] = int(dtag[2])
+            cell[next, 3] = int(dtag[3])
+            cell[next, 4] = int(dtag[4])
+            cell[next, 5] = int(dtag[5])
+
+            itag[next] = int(dtag[6])
         else:
-            raise Exception( \
-            "Invalid WEDG6 data: "+ data)
+            raise Exception(
+                "Invalid WEDG6 data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadbound(mesh,file,ltag):
+def loadbound(mesh, file, ltag):
     """
     LOADBOUND: load the BOUND data segment from file.
-    
+
     """
     lnum = int(ltag[1])
     next = +0
-    
-    mesh.bound = np.empty( \
+
+    mesh.bound = np.empty(
         lnum, dtype=jigsaw_msh_t.BOUND_t)
 
     itag = mesh.bound["IDtag"]
@@ -440,156 +441,156 @@ def loadbound(mesh,file,ltag):
     while (lnum >= +1):
         data = file.readline()
         dtag = data.split(";")
-    
+
         if (len(dtag) == +3):
-            itag[next]   = int  (dtag[0])
-            indx[next]   = int  (dtag[1])
-            kind[next]   = int  (dtag[2])
+            itag[next] = int(dtag[0])
+            indx[next] = int(dtag[1])
+            kind[next] = int(dtag[2])
         else:
-            raise Exception( \
-            "Invalid BOUND data: "+ data)
+            raise Exception(
+                "Invalid BOUND data: " + data)
 
         lnum -= +1
         next += +1
-        
+
     return
 
 
-def loadcoord(mesh,file,ltag):
+def loadcoord(mesh, file, ltag):
     """
     LOADCOORD: load the COORD data segment from file.
-    
+
     """
     ctag = ltag[1].split(";")
 
     idim = int(ctag[0])
     lnum = int(ctag[1])
     next = +0
-    
-    if   (idim == +1):
-        mesh.xgrid = np.empty( \
-            lnum,dtype=jigsaw_msh_t.REALS_t)
+
+    if (idim == +1):
+        mesh.xgrid = np.empty(
+            lnum, dtype=jigsaw_msh_t.REALS_t)
 
         data = mesh.xgrid[:]
 
     elif (idim == +2):
-        mesh.ygrid = np.empty( \
-            lnum,dtype=jigsaw_msh_t.REALS_t)
+        mesh.ygrid = np.empty(
+            lnum, dtype=jigsaw_msh_t.REALS_t)
 
         data = mesh.ygrid[:]
 
     elif (idim == +3):
-        mesh.zgrid = np.empty( \
-            lnum,dtype=jigsaw_msh_t.REALS_t)
+        mesh.zgrid = np.empty(
+            lnum, dtype=jigsaw_msh_t.REALS_t)
 
         data = mesh.zgrid[:]
 
     while (lnum >= +1):
-        data[next] = float(file.readline ())
-    
+        data[next] = float(file.readline())
+
         lnum -= +1
         next += +1
 
     return
-      
-        
-def loadlines(mesh,file,line):
+
+
+def loadlines(mesh, file, line):
     """
     LOADLINES: load the next non-null line from file.
-    
+
     """
-    
-    #------------------------------ skip any 'comment' lines
-   
+
+    # ------------------------------ skip any 'comment' lines
+
     if (line[0] != '#'):
-    
-    #------------------------------ split about '=' charact.
+
+        # ------------------------------ split about '=' charact.
         ltag = line.split("=")
         kind = ltag[0].upper()
-        
-        if   (kind == "MSHID"):
-        
-    #----------------------------------- parse MSHID struct.
+
+        if (kind == "MSHID"):
+
+            # ----------------------------------- parse MSHID struct.
             data = ltag[1].split(";")
 
             if (len(data) > 1):
                 mesh.mshID = \
-            data[1].strip().lower()
-            
+                    data[1].strip().lower()
+
         elif (kind == "NDIMS"):
-        
-    #----------------------------------- parse NDIMS struct.
+
+            # ----------------------------------- parse NDIMS struct.
             mesh.ndims = int(ltag[1])
-        
+
         elif (kind == "RADII"):
-    
-    #----------------------------------- parse RADII struct.
-            loadradii(mesh,file,ltag)
-    
+
+            # ----------------------------------- parse RADII struct.
+            loadradii(mesh, file, ltag)
+
         elif (kind == "POINT"):
-    
-    #----------------------------------- parse POINT struct.
-            loadpoint(mesh,file,ltag)
+
+            # ----------------------------------- parse POINT struct.
+            loadpoint(mesh, file, ltag)
 
         elif (kind == "POWER"):
-    
-    #----------------------------------- parse POWER struct.
-            loadpower(mesh,file,ltag)
+
+            # ----------------------------------- parse POWER struct.
+            loadpower(mesh, file, ltag)
 
         elif (kind == "VALUE"):
-   
-    #----------------------------------- parse VALUE struct.
-            loadvalue(mesh,file,ltag)
-                
+
+            # ----------------------------------- parse VALUE struct.
+            loadvalue(mesh, file, ltag)
+
         elif (kind == "EDGE2"):
-        
-    #----------------------------------- parse EDGE2 struct.
-            loadedge2(mesh,file,ltag)
-                
+
+            # ----------------------------------- parse EDGE2 struct.
+            loadedge2(mesh, file, ltag)
+
         elif (kind == "TRIA3"):
-   
-    #----------------------------------- parse TRIA3 struct.
-            loadtria3(mesh,file,ltag)
-                
+
+            # ----------------------------------- parse TRIA3 struct.
+            loadtria3(mesh, file, ltag)
+
         elif (kind == "QUAD4"):
-   
-    #----------------------------------- parse QUAD4 struct.
-            loadquad4(mesh,file,ltag)
-                
+
+            # ----------------------------------- parse QUAD4 struct.
+            loadquad4(mesh, file, ltag)
+
         elif (kind == "TRIA4"):
-   
-    #----------------------------------- parse TRIA4 struct.
-            loadtria4(mesh,file,ltag)
-                
+
+            # ----------------------------------- parse TRIA4 struct.
+            loadtria4(mesh, file, ltag)
+
         elif (kind == "HEXA8"):
-   
-    #----------------------------------- parse HEXA8 struct.
-            loadhexa8(mesh,file,ltag)
+
+            # ----------------------------------- parse HEXA8 struct.
+            loadhexa8(mesh, file, ltag)
 
         elif (kind == "PYRA5"):
-   
-    #----------------------------------- parse PYRA5 struct.
-            loadpyra5(mesh,file,ltag)
+
+            # ----------------------------------- parse PYRA5 struct.
+            loadpyra5(mesh, file, ltag)
 
         elif (kind == "WEDG6"):
-   
-    #----------------------------------- parse WEDG6 struct.
-            loadwedg6(mesh,file,ltag)
+
+            # ----------------------------------- parse WEDG6 struct.
+            loadwedg6(mesh, file, ltag)
 
         elif (kind == "BOUND"):
-   
-    #----------------------------------- parse BOUND struct.
-            loadbound(mesh,file,ltag)
+
+            # ----------------------------------- parse BOUND struct.
+            loadbound(mesh, file, ltag)
 
         elif (kind == "COORD"):
-   
-    #----------------------------------- parse COORD struct.
-            loadcoord(mesh,file,ltag)
-        
+
+            # ----------------------------------- parse COORD struct.
+            loadcoord(mesh, file, ltag)
+
     return
 
 
-def loadmsh(name,mesh):
+def loadmsh(name, mesh):
     """
     LOADMSH: load a JIGSAW MSH obj. from file.
 
@@ -600,32 +601,29 @@ def loadmsh(name,mesh):
 
     Data in MESH is loaded on-demand -- any objects included
     in the file will be read.
-    
+
     """
 
-    if (not isinstance(name,str)):
+    if (not isinstance(name, str)):
         raise Exception("Incorrect type: NAME.")
-        
-    if (not isinstance(mesh,jigsaw_msh_t)):
+
+    if (not isinstance(mesh, jigsaw_msh_t)):
         raise Exception("Incorrect type: MESH.")
 
     with Path(name).open("r") as file:
         while (True):
-        
-    #--------------------------- get the next line from file    
-            line = file.readline ()
-            
+
+            # --------------------------- get the next line from file
+            line = file.readline()
+
             if (len(line) != +0):
 
-    #--------------------------- parse next non-null section
+                # --------------------------- parse next non-null section
                 loadlines(
-                    mesh,file,line)                    
-            
+                    mesh, file, line)
+
             else:
-    #--------------------------- reached end-of-file: done!!
+                # --------------------------- reached end-of-file: done!!
                 break
 
     return
-
-
-

--- a/jigsawpy/msh_l.py
+++ b/jigsawpy/msh_l.py
@@ -3,240 +3,260 @@ import ctypes as ct
 
 from jigsawpy.def_t import indx_t, real_t
 
-#------------------------------------------- POINT struct.'s
+# ------------------------------------------- POINT struct.'s
+
 
 class libsaw_VERT2_t(ct.Structure):
-    _fields_ = [("ppos", real_t*2), 
+    _fields_ = [("ppos", real_t * 2),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_VERT2_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_VERT2_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_VERT2_t))
+                ]
+
 
 class libsaw_VERT3_t(ct.Structure):
-    _fields_ = [("ppos", real_t*3), 
+    _fields_ = [("ppos", real_t * 3),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_VERT3_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_VERT3_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_VERT3_t))
+                ]
 
-#------------------------------------------- 1-CEL struct.'s
+# ------------------------------------------- 1-CEL struct.'s
+
 
 class libsaw_EDGE2_t(ct.Structure):
-    _fields_ = [("node", indx_t*2), 
+    _fields_ = [("node", indx_t * 2),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_EDGE2_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_EDGE2_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_EDGE2_t))
+                ]
 
-#------------------------------------------- 2-CEL struct.'s
+# ------------------------------------------- 2-CEL struct.'s
+
 
 class libsaw_TRIA3_t(ct.Structure):
-    _fields_ = [("node", indx_t*3), 
+    _fields_ = [("node", indx_t * 3),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_TRIA3_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_TRIA3_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_TRIA3_t))
+                ]
+
 
 class libsaw_QUAD4_t(ct.Structure):
-    _fields_ = [("node", indx_t*4), 
+    _fields_ = [("node", indx_t * 4),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_QUAD4_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_QUAD4_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_QUAD4_t))
+                ]
 
-#------------------------------------------- 3-CEL struct.'s
+# ------------------------------------------- 3-CEL struct.'s
+
 
 class libsaw_TRIA4_t(ct.Structure):
-    _fields_ = [("node", indx_t*4), 
+    _fields_ = [("node", indx_t * 4),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_TRIA4_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_TRIA4_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_TRIA4_t))
+                ]
+
 
 class libsaw_HEXA8_t(ct.Structure):
-    _fields_ = [("node", indx_t*8), 
+    _fields_ = [("node", indx_t * 8),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_HEXA8_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_HEXA8_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_HEXA8_t))
+                ]
+
 
 class libsaw_WEDG6_t(ct.Structure):
-    _fields_ = [("node", indx_t*6), 
+    _fields_ = [("node", indx_t * 6),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_WEDG6_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_WEDG6_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_WEDG6_t))
+                ]
+
 
 class libsaw_PYRA5_t(ct.Structure):
-    _fields_ = [("node", indx_t*5), 
+    _fields_ = [("node", indx_t * 5),
                 ("itag", indx_t)
-               ]
+                ]
+
 
 class libsaw_PYRA5_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_PYRA5_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_PYRA5_t))
+                ]
 
-#------------------------------------------- BOUND struct.'s
+# ------------------------------------------- BOUND struct.'s
+
 
 class libsaw_BOUND_t(ct.Structure):
     _fields_ = [("itag", indx_t),
-                ("indx", indx_t), 
+                ("indx", indx_t),
                 ("kind", indx_t)
-               ]
+                ]
+
 
 class libsaw_BOUND_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(libsaw_BOUND_t))
-               ]
+                ("data",
+                 ct.POINTER(libsaw_BOUND_t))
+                ]
 
-#------------------------------------------- MISC. struct.'s
+# ------------------------------------------- MISC. struct.'s
+
 
 class libsaw_REALS_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(real_t))
-               ]
+                ("data",
+                 ct.POINTER(real_t))
+                ]
+
 
 class libsaw_INDEX_array_t(ct.Structure):
     _fields_ = [("size", indx_t),
-                ("data", \
-              ct.POINTER(indx_t))
-               ]
+                ("data",
+                 ct.POINTER(indx_t))
+                ]
 
-#---------------------------- ctypes struct for JIGSAW's API
+# ---------------------------- ctypes struct for JIGSAW's API
+
 
 class libsaw_msh_t(ct.Structure):
-    _fields_ = [("flags",indx_t),
+    _fields_ = [("flags", indx_t),
 
-    # VERT2 - 2-dim. vertex coordinates
-    # VERT2 is an array of libsaw_VERT2_t struct.'s, where:
-    # VERT2.DATA[:].PPOS is an array of coordinate values,
-    # VERT2.DATA[:].ITAG is an array of associated ID tags.
+                # VERT2 - 2-dim. vertex coordinates
+                # VERT2 is an array of libsaw_VERT2_t struct.'s, where:
+                # VERT2.DATA[:].PPOS is an array of coordinate values,
+                # VERT2.DATA[:].ITAG is an array of associated ID tags.
 
-    ("vert2",libsaw_VERT2_array_t),
+                ("vert2", libsaw_VERT2_array_t),
 
-    # VERT3 - 3-dim. vertex coordinates
-    # VERT3 is an array of libsaw_VERT3_t struct.'s, where:
-    # VERT3.DATA[:].PPOS is an array of coordinate values,
-    # VERT3.DATA[:].ITAG is an array of associated ID tags.
+                # VERT3 - 3-dim. vertex coordinates
+                # VERT3 is an array of libsaw_VERT3_t struct.'s, where:
+                # VERT3.DATA[:].PPOS is an array of coordinate values,
+                # VERT3.DATA[:].ITAG is an array of associated ID tags.
 
-    ("vert3",libsaw_VERT3_array_t),
+                ("vert3", libsaw_VERT3_array_t),
 
-    # POWER - vertex "weights" associated with dual "power" 
-    # tessellation.
+                # POWER - vertex "weights" associated with dual "power"
+                # tessellation.
 
-    ("power",libsaw_REALS_array_t),
+                ("power", libsaw_REALS_array_t),
 
-    # EDGE2 - EDGE-2 element definitions
-    # EDGE2 is an array of libsaw_EDGE2_t struct.'s, where:
-    # EDGE2.DATA[:].NODE is an array of element indexing,
-    # EDGE2.DATA[:].ITAG is an array of associated ID tags.
+                # EDGE2 - EDGE-2 element definitions
+                # EDGE2 is an array of libsaw_EDGE2_t struct.'s, where:
+                # EDGE2.DATA[:].NODE is an array of element indexing,
+                # EDGE2.DATA[:].ITAG is an array of associated ID tags.
 
-    ("edge2",libsaw_EDGE2_array_t),
+                ("edge2", libsaw_EDGE2_array_t),
 
-    # TRIA3 - TRIA-3 element definitions
-    # TRIA3 is an array of libsaw_TRIA3_t struct.'s, where:
-    # TRIA3.DATA[:].NODE is an array of element indexing,
-    # TRIA3.DATA[:].ITAG is an array of associated ID tags.
+                # TRIA3 - TRIA-3 element definitions
+                # TRIA3 is an array of libsaw_TRIA3_t struct.'s, where:
+                # TRIA3.DATA[:].NODE is an array of element indexing,
+                # TRIA3.DATA[:].ITAG is an array of associated ID tags.
 
-    ("tria3",libsaw_TRIA3_array_t),
+                ("tria3", libsaw_TRIA3_array_t),
 
-    # QUAD4 - QUAD-4 element definitions
-    # QUAD4 is an array of libsaw_QUAD4_t struct.'s, where:
-    # QUAD4.DATA[:].NODE is an array of element indexing,
-    # QUAD4.DATA[:].ITAG is an array of associated ID tags.
+                # QUAD4 - QUAD-4 element definitions
+                # QUAD4 is an array of libsaw_QUAD4_t struct.'s, where:
+                # QUAD4.DATA[:].NODE is an array of element indexing,
+                # QUAD4.DATA[:].ITAG is an array of associated ID tags.
 
-    ("quad4",libsaw_QUAD4_array_t),
+                ("quad4", libsaw_QUAD4_array_t),
 
-    # TRIA4 - TRIA-4 element definitions
-    # TRIA4 is an array of libsaw_TRIA4_t struct.'s, where:
-    # TRIA4.DATA[:].NODE is an array of element indexing,
-    # TRIA4.DATA[:].ITAG is an array of associated ID tags.    
+                # TRIA4 - TRIA-4 element definitions
+                # TRIA4 is an array of libsaw_TRIA4_t struct.'s, where:
+                # TRIA4.DATA[:].NODE is an array of element indexing,
+                # TRIA4.DATA[:].ITAG is an array of associated ID tags.
 
-    ("tria4",libsaw_TRIA4_array_t),
+                ("tria4", libsaw_TRIA4_array_t),
 
-    # HEXA8 - HEXA-8 element definitions
-    # HEXA8 is an array of libsaw_HEXA8_t struct.'s, where:
-    # HEXA8.DATA[:].NODE is an array of element indexing,
-    # HEXA8.DATA[:].ITAG is an array of associated ID tags.
+                # HEXA8 - HEXA-8 element definitions
+                # HEXA8 is an array of libsaw_HEXA8_t struct.'s, where:
+                # HEXA8.DATA[:].NODE is an array of element indexing,
+                # HEXA8.DATA[:].ITAG is an array of associated ID tags.
 
-    ("hexa8",libsaw_HEXA8_array_t),
+                ("hexa8", libsaw_HEXA8_array_t),
 
-    # WEDG6 - WEDG-6 element definitions
-    # WEDG6 is an array of libsaw_WEDG6_t struct.'s, where:
-    # WEDG6.DATA[:].NODE is an array of element indexing,
-    # WEDG6.DATA[:].ITAG is an array of associated ID tags.
+                # WEDG6 - WEDG-6 element definitions
+                # WEDG6 is an array of libsaw_WEDG6_t struct.'s, where:
+                # WEDG6.DATA[:].NODE is an array of element indexing,
+                # WEDG6.DATA[:].ITAG is an array of associated ID tags.
 
-    ("wedg6",libsaw_WEDG6_array_t),
+                ("wedg6", libsaw_WEDG6_array_t),
 
-    # PYRA5 - PYRA-5 element definitions
-    # PYRA5 is an array of libsaw_PYRA5_t struct.'s, where:
-    # PYRA5.DATA[:].NODE is an array of element indexing,
-    # PYRA5.DATA[:].ITAG is an array of associated ID tags.
+                # PYRA5 - PYRA-5 element definitions
+                # PYRA5 is an array of libsaw_PYRA5_t struct.'s, where:
+                # PYRA5.DATA[:].NODE is an array of element indexing,
+                # PYRA5.DATA[:].ITAG is an array of associated ID tags.
 
-    ("pyra5",libsaw_PYRA5_array_t),
-    
-    # BOUND - "boundary" indexing,
-    # BOUND is an array of libsaw_BOUND_t struct.'s, which
-    # describe how elements in the geometry are associated 
-    # with enclosed areas/volumes, herein known as "parts":
-    # BOUND.DATA[:].INDX is an array of cell indexing,        
-    # BOUND.DATA[:].KIND is an array of cell tags, defining 
-    # which element "kind" is indexed via BOUND.DATA.INDX
-    # BOUND.DATA[:].ITAG is an array of associated ID tags.
- 
-    ("bound",libsaw_BOUND_array_t),
+                ("pyra5", libsaw_PYRA5_array_t),
 
-    # RADII - 3-by-1 array of principal ellipsoid radii.
+                # BOUND - "boundary" indexing,
+                # BOUND is an array of libsaw_BOUND_t struct.'s, which
+                # describe how elements in the geometry are associated
+                # with enclosed areas/volumes, herein known as "parts":
+                # BOUND.DATA[:].INDX is an array of cell indexing,
+                # BOUND.DATA[:].KIND is an array of cell tags, defining
+                # which element "kind" is indexed via BOUND.DATA.INDX
+                # BOUND.DATA[:].ITAG is an array of associated ID tags.
 
-    ("radii",libsaw_REALS_array_t),
+                ("bound", libsaw_BOUND_array_t),
 
-    # KGRID - array of "k-axis" grid coordinates for "grid"
-    # type objects. Coordinates must vary monotonically.
+                # RADII - 3-by-1 array of principal ellipsoid radii.
 
-    ("xgrid",libsaw_REALS_array_t),
-    ("ygrid",libsaw_REALS_array_t),
-    ("zgrid",libsaw_REALS_array_t),
+                ("radii", libsaw_REALS_array_t),
 
-    # VALUE - "values" associated with the vertices of the 
-    # mesh object.
+                # KGRID - array of "k-axis" grid coordinates for "grid"
+                # type objects. Coordinates must vary monotonically.
 
-    ("value",libsaw_REALS_array_t)]
+                ("xgrid", libsaw_REALS_array_t),
+                ("ygrid", libsaw_REALS_array_t),
+                ("zgrid", libsaw_REALS_array_t),
 
+                # VALUE - "values" associated with the vertices of the
+                # mesh object.
 
-
+                ("value", libsaw_REALS_array_t)]

--- a/jigsawpy/msh_t.py
+++ b/jigsawpy/msh_t.py
@@ -1,9 +1,9 @@
 
 """ MSH_T: Container struct. for JIGSAW's mesh data.
- 
+
     .IF. MESH.MSHID == 'EUCLIDEAN-MESH':
     -----------------------------------
- 
+
     MESH.VERT2 - [V2x 1] array of 2dim. point coordinates,
         VERT2 is a JIGSAW_MSH_t.VERT2_t structure, where:
         VERT2["COORD"] is an array of coordinate values,
@@ -14,14 +14,14 @@
         VERT3["COORD"] is an array of coordinate values,
         VERT3["IDTAG"] is an ID tag assigned at each vertex.
 
-    MESH.POWER - [NVx 1] array of vertex "weights" 
+    MESH.POWER - [NVx 1] array of vertex "weights"
         associated with the dual "power" tessellation.
- 
+
     MESH.EDGE2 - [E2x 1] array of EDGE-2 cell definitions,
         EDGE2 is a JIGSAW_MSH_t.EDGE2_t structure, where:
         EDGE2["INDEX"] is an array of cell indexing,
-        EDGE2["IDTAG"] is an ID tag assigned at each cell. 
- 
+        EDGE2["IDTAG"] is an ID tag assigned at each cell.
+
     MESH.TRIA3 - [T3x 1] array of TRIA-3 cell definitions,
         TRIA3 is a JIGSAW_MSH_t.TRIA3_t structure, where:
         TRIA3["INDEX"] is an array of cell indexing,
@@ -53,137 +53,135 @@
         PYRA5["IDTAG"] is an ID tag assigned at each cell.
 
     MESH.BOUND - [NBx 1] array of "boundary" indexing,
-        BOUND is a JIGSAW_MSH_t.BOUND_t structure, defining 
-        how elements in the geometry are associated with 
+        BOUND is a JIGSAW_MSH_t.BOUND_t structure, defining
+        how elements in the geometry are associated with
         enclosed areas/volumes, herein known as "parts":
-        BOUND["INDEX"] is an array of cell indexing,        
-        BOUND["CELLS"] is an array of cell tags, defining 
+        BOUND["INDEX"] is an array of cell indexing,
+        BOUND["CELLS"] is an array of cell tags, defining
         which element "kind" is indexed via BOUND["INDEX"]
         BOUND["IDTAG"] is an ID tag assigned to each part.
- 
-        In the default case, where BOUND is not specified, 
+
+        In the default case, where BOUND is not specified,
         all elements in the geometry are assumed to define
         the boundaries of enclosed "parts".
- 
+
     MESH.VALUE - [NPxNV] array of "values" associated with
         the vertices of the mesh.
- 
+
     .IF. MESH.MSHID == 'ELLIPSOID-MESH':
     -----------------------------------
- 
+
     MESH.RADII - [ 3x 1] array of principal ellipsoid radii.
- 
+
     Additionally, entities described in the 'EUCLIDEAN-MESH'
     specification may be optionally defined.
- 
+
     .IF. MESH.MSHID == 'EUCLIDEAN-GRID':
     .OR. MESH.MSHID == 'ELLIPSOID-GRID':
     -----------------------------------
- 
-    MESH.XGRID - [NXx 1] array of "x-axis" grid coordinates. 
+
+    MESH.XGRID - [NXx 1] array of "x-axis" grid coordinates.
         Values must increase or decrease monotonically.
- 
-    MESH.YGRID - [NYx 1] array of "y-axis" grid coordinates. 
+
+    MESH.YGRID - [NYx 1] array of "y-axis" grid coordinates.
         Values must increase or decrease monotonically.
- 
-    MESH.ZGRID - [NZx 1] array of "z-axis" grid coordinates. 
+
+    MESH.ZGRID - [NZx 1] array of "z-axis" grid coordinates.
         Values must increase or decrease monotonically.
- 
-    MESH.VALUE - [NMxNV] array of "values" associated with 
+
+    MESH.VALUE - [NMxNV] array of "values" associated with
         the vertices of the grid, where NM is the product of
-        the dimensions of the grid. NV values are associated 
+        the dimensions of the grid. NV values are associated
         with each vertex.
- 
+
     See also JIG_t
- 
+
 
     --------------------------------------------------------
-    """ 
+    """
 
 import numpy as np
 
+
 class jigsaw_msh_t:
-    #------------------------------------------ MESH typedef
+    # ------------------------------------------ MESH typedef
     REALS_t = np.float64
     INDEX_t = np.  int32
 
-    VERT2_t = np.dtype([("coord",REALS_t,2), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    VERT3_t = np.dtype([("coord",REALS_t,3), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
+    VERT2_t = np.dtype([("coord", REALS_t, 2),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    VERT3_t = np.dtype([("coord", REALS_t, 3),
+                        ("IDtag", INDEX_t)],
+                       align=True)
 
-    EDGE2_t = np.dtype([("index",INDEX_t,2), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    TRIA3_t = np.dtype([("index",INDEX_t,3), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    QUAD4_t = np.dtype([("index",INDEX_t,4), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    TRIA4_t = np.dtype([("index",INDEX_t,4), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    HEXA8_t = np.dtype([("index",INDEX_t,8), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    WEDG6_t = np.dtype([("index",INDEX_t,6), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
-    PYRA5_t = np.dtype([("index",INDEX_t,5), \
-                        ("IDtag",INDEX_t)] , \
-                          align =True )
+    EDGE2_t = np.dtype([("index", INDEX_t, 2),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    TRIA3_t = np.dtype([("index", INDEX_t, 3),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    QUAD4_t = np.dtype([("index", INDEX_t, 4),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    TRIA4_t = np.dtype([("index", INDEX_t, 4),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    HEXA8_t = np.dtype([("index", INDEX_t, 8),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    WEDG6_t = np.dtype([("index", INDEX_t, 6),
+                        ("IDtag", INDEX_t)],
+                       align=True)
+    PYRA5_t = np.dtype([("index", INDEX_t, 5),
+                        ("IDtag", INDEX_t)],
+                       align=True)
 
-    BOUND_t = np.dtype([("IDtag",INDEX_t)  , \
-                        ("index",INDEX_t)  , \
-                        ("cells",INDEX_t)] , \
-                          align =True )
+    BOUND_t = np.dtype([("IDtag", INDEX_t),
+                        ("index", INDEX_t),
+                        ("cells", INDEX_t)],
+                       align=True)
 
     def __init__(self):
-    #------------------------------------------ MESH struct.
+        # ------------------------------------------ MESH struct.
         self.mshID = "euclidean-mesh"
         self.ndims = +0
-    
+
         self.radii = \
-    np.empty([0],  dtype=jigsaw_msh_t.REALS_t)
+            np.empty([0], dtype=jigsaw_msh_t.REALS_t)
 
         self.vert2 = \
-    np.empty([0],  dtype=jigsaw_msh_t.VERT2_t)
+            np.empty([0], dtype=jigsaw_msh_t.VERT2_t)
         self.vert3 = \
-    np.empty([0],  dtype=jigsaw_msh_t.VERT3_t)
+            np.empty([0], dtype=jigsaw_msh_t.VERT3_t)
 
         self.power = \
-    np.empty([0,0],dtype=jigsaw_msh_t.REALS_t)
-        
+            np.empty([0, 0], dtype=jigsaw_msh_t.REALS_t)
+
         self.edge2 = \
-    np.empty([0],  dtype=jigsaw_msh_t.EDGE2_t)
+            np.empty([0], dtype=jigsaw_msh_t.EDGE2_t)
         self.tria3 = \
-    np.empty([0],  dtype=jigsaw_msh_t.TRIA3_t)
+            np.empty([0], dtype=jigsaw_msh_t.TRIA3_t)
         self.quad4 = \
-    np.empty([0],  dtype=jigsaw_msh_t.QUAD4_t)
+            np.empty([0], dtype=jigsaw_msh_t.QUAD4_t)
         self.tria4 = \
-    np.empty([0],  dtype=jigsaw_msh_t.TRIA4_t)
+            np.empty([0], dtype=jigsaw_msh_t.TRIA4_t)
         self.hexa8 = \
-    np.empty([0],  dtype=jigsaw_msh_t.HEXA8_t)
+            np.empty([0], dtype=jigsaw_msh_t.HEXA8_t)
         self.pyra5 = \
-    np.empty([0],  dtype=jigsaw_msh_t.PYRA5_t)
+            np.empty([0], dtype=jigsaw_msh_t.PYRA5_t)
         self.wedg6 = \
-    np.empty([0],  dtype=jigsaw_msh_t.WEDG6_t)
+            np.empty([0], dtype=jigsaw_msh_t.WEDG6_t)
 
         self.bound = \
-    np.empty([0],  dtype=jigsaw_msh_t.BOUND_t)
-        
+            np.empty([0], dtype=jigsaw_msh_t.BOUND_t)
+
         self.xgrid = \
-    np.empty([0],  dtype=jigsaw_msh_t.REALS_t)
+            np.empty([0], dtype=jigsaw_msh_t.REALS_t)
         self.ygrid = \
-    np.empty([0],  dtype=jigsaw_msh_t.REALS_t)
+            np.empty([0], dtype=jigsaw_msh_t.REALS_t)
         self.zgrid = \
-    np.empty([0],  dtype=jigsaw_msh_t.REALS_t)
-        
+            np.empty([0], dtype=jigsaw_msh_t.REALS_t)
+
         self.value = \
-    np.empty([0,0],dtype=jigsaw_msh_t.REALS_t)
-
-
-
+            np.empty([0, 0], dtype=jigsaw_msh_t.REALS_t)

--- a/jigsawpy/savejig.py
+++ b/jigsawpy/savejig.py
@@ -1,50 +1,54 @@
-  
+
 from pathlib import Path
-from jigsawpy.jig_t  import jigsaw_jig_t
+from jigsawpy.jig_t import jigsaw_jig_t
 
-def savechar(file,sval,stag):
 
-    if (isinstance(sval,str)):
+def savechar(file, sval, stag):
+
+    if (isinstance(sval, str)):
         file.write("  " + stag + "=" + sval + "\n")
     else:
-        raise Exception("Invalid data: OPTS."+stag)
+        raise Exception("Invalid data: OPTS." + stag)
 
     return
 
-def saveints(file,ival,stag):
 
-    if (isinstance(ival,int)):
-        file.write( \
+def saveints(file, ival, stag):
+
+    if (isinstance(ival, int)):
+        file.write(
             "  " + stag + "=" + str(ival) + "\n")
     else:
-        raise Exception("Invalid data: OPTS."+stag)
+        raise Exception("Invalid data: OPTS." + stag)
 
     return
-    
-def savereal(file,fval,stag):
 
-    if (isinstance(fval,float)):
-        file.write( \
+
+def savereal(file, fval, stag):
+
+    if (isinstance(fval, float)):
+        file.write(
             "  " + stag + "=" + str(fval) + "\n")
     else:
-        raise Exception("Invalid data: OPTS."+stag)
+        raise Exception("Invalid data: OPTS." + stag)
 
     return
-    
-def savebool(file,bval,stag):
 
-    if (isinstance(bval,bool)):
-        if (bval == True):
+
+def savebool(file, bval, stag):
+
+    if (isinstance(bval, bool)):
+        if bval:
             file.write("  " + stag + "=TRUE \n")
         else:
             file.write("  " + stag + "=FALSE\n")
     else:
-        raise Exception("Invalid data: OPTS."+stag)
+        raise Exception("Invalid data: OPTS." + stag)
 
     return
 
 
-def savejig(name,opts):
+def savejig(name, opts):
     """
     SAVEJIG: save a JIG config. obj. to file.
 
@@ -55,142 +59,139 @@ def savejig(name,opts):
 
     Data in OPTS is written as-needed -- any objects defined
     will be saved to file.
-    
+
     """
 
-    if (not isinstance(name,str)):
+    if (not isinstance(name, str)):
         raise Exception("Incorrect type: NAME.")
-        
-    if (not isinstance(opts,jigsaw_jig_t)):
+
+    if (not isinstance(opts, jigsaw_jig_t)):
         raise Exception("Incorrect type: OPTS.")
 
     fext = Path(name).suffix
-    
+
     if (fext.strip() != ".jig"):
-        name =   name + ".jig"
+        name = name + ".jig"
 
     with Path(name).open("w") as file:
-        
-        file.write("# " + Path(name).name + \
-    " config. file; created by JIGSAW's PYTHON interface \n")
-        
-    #------------------------------------------ MISC options
-        if (opts.verbosity is not None):
-            saveints(file,opts.verbosity,"VERBOSITY")
-            
-        if (opts.tria_file is not None):
-            savechar(file,opts.tria_file,"TRIA_FILE")
-        if (opts.bnds_file is not None):
-            savechar(file,opts.bnds_file,"BNDS_FILE")            
 
-    #------------------------------------------ INIT options
+        file.write("# " + Path(name).name +
+                   " config. file; created by JIGSAW's PYTHON interface \n")
+
+    # ------------------------------------------ MISC options
+        if (opts.verbosity is not None):
+            saveints(file, opts.verbosity, "VERBOSITY")
+
+        if (opts.tria_file is not None):
+            savechar(file, opts.tria_file, "TRIA_FILE")
+        if (opts.bnds_file is not None):
+            savechar(file, opts.bnds_file, "BNDS_FILE")
+
+    # ------------------------------------------ INIT options
         if (opts.init_file is not None):
-            savechar(file,opts.init_file,"INIT_FILE")
+            savechar(file, opts.init_file, "INIT_FILE")
 
         if (opts.init_near is not None):
-            savereal(file,opts.init_near,"INIT_NEAR")
-            
-    #------------------------------------------ GEOM options
+            savereal(file, opts.init_near, "INIT_NEAR")
+
+    # ------------------------------------------ GEOM options
         if (opts.geom_file is not None):
-            savechar(file,opts.geom_file,"GEOM_FILE")
-            
+            savechar(file, opts.geom_file, "GEOM_FILE")
+
         if (opts.geom_seed is not None):
-            saveints(file,opts.geom_seed,"GEOM_SEED")
-            
+            saveints(file, opts.geom_seed, "GEOM_SEED")
+
         if (opts.geom_feat is not None):
-            savebool(file,opts.geom_feat,"GEOM_FEAT")
-        
+            savebool(file, opts.geom_feat, "GEOM_FEAT")
+
         if (opts.geom_phi1 is not None):
-            savereal(file,opts.geom_phi1,"GEOM_PHI1")
+            savereal(file, opts.geom_phi1, "GEOM_PHI1")
         if (opts.geom_phi2 is not None):
-            savereal(file,opts.geom_phi2,"GEOM_PHI2")
-            
+            savereal(file, opts.geom_phi2, "GEOM_PHI2")
+
         if (opts.geom_eta1 is not None):
-            savereal(file,opts.geom_eta1,"GEOM_ETA1")
+            savereal(file, opts.geom_eta1, "GEOM_ETA1")
         if (opts.geom_eta2 is not None):
-            savereal(file,opts.geom_eta2,"GEOM_ETA2")
-            
-    #------------------------------------------ HFUN options
+            savereal(file, opts.geom_eta2, "GEOM_ETA2")
+
+    # ------------------------------------------ HFUN options
         if (opts.hfun_file is not None):
-            savechar(file,opts.hfun_file,"HFUN_FILE")
-            
+            savechar(file, opts.hfun_file, "HFUN_FILE")
+
         if (opts.hfun_scal is not None):
-            savechar(file,opts.hfun_scal,"HFUN_SCAL")
-            
+            savechar(file, opts.hfun_scal, "HFUN_SCAL")
+
         if (opts.hfun_hmax is not None):
-            savereal(file,opts.hfun_hmax,"HFUN_HMAX")
+            savereal(file, opts.hfun_hmax, "HFUN_HMAX")
         if (opts.hfun_hmin is not None):
-            savereal(file,opts.hfun_hmin,"HFUN_HMIN")
-            
-    #------------------------------------------ MESH options
+            savereal(file, opts.hfun_hmin, "HFUN_HMIN")
+
+    # ------------------------------------------ MESH options
         if (opts.mesh_file is not None):
-            savechar(file,opts.mesh_file,"MESH_FILE")
-            
+            savechar(file, opts.mesh_file, "MESH_FILE")
+
         if (opts.mesh_kern is not None):
-            savechar(file,opts.mesh_kern,"MESH_KERN")
+            savechar(file, opts.mesh_kern, "MESH_KERN")
         if (opts.bnds_kern is not None):
-            savechar(file,opts.bnds_kern,"BNDS_KERN")
-            
+            savechar(file, opts.bnds_kern, "BNDS_KERN")
+
         if (opts.mesh_iter is not None):
-            saveints(file,opts.mesh_iter,"MESH_ITER")
-            
+            saveints(file, opts.mesh_iter, "MESH_ITER")
+
         if (opts.mesh_dims is not None):
-            saveints(file,opts.mesh_dims,"MESH_DIMS")
-            
+            saveints(file, opts.mesh_dims, "MESH_DIMS")
+
         if (opts.mesh_top1 is not None):
-            savebool(file,opts.mesh_top1,"MESH_TOP1")
+            savebool(file, opts.mesh_top1, "MESH_TOP1")
         if (opts.mesh_top2 is not None):
-            savebool(file,opts.mesh_top2,"MESH_TOP2")
-            
+            savebool(file, opts.mesh_top2, "MESH_TOP2")
+
         if (opts.mesh_siz1 is not None):
-            savereal(file,opts.mesh_siz1,"MESH_SIZ1")
+            savereal(file, opts.mesh_siz1, "MESH_SIZ1")
         if (opts.mesh_siz2 is not None):
-            savereal(file,opts.mesh_siz2,"MESH_SIZ2")
+            savereal(file, opts.mesh_siz2, "MESH_SIZ2")
         if (opts.mesh_siz3 is not None):
-            savereal(file,opts.mesh_siz3,"MESH_SIZ3")
-            
+            savereal(file, opts.mesh_siz3, "MESH_SIZ3")
+
         if (opts.mesh_eps1 is not None):
-            savereal(file,opts.mesh_eps1,"MESH_EPS1")
+            savereal(file, opts.mesh_eps1, "MESH_EPS1")
         if (opts.mesh_eps2 is not None):
-            savereal(file,opts.mesh_eps2,"MESH_EPS2")
-        
+            savereal(file, opts.mesh_eps2, "MESH_EPS2")
+
         if (opts.mesh_rad2 is not None):
-            savereal(file,opts.mesh_rad2,"MESH_RAD2")
+            savereal(file, opts.mesh_rad2, "MESH_RAD2")
         if (opts.mesh_rad3 is not None):
-            savereal(file,opts.mesh_rad3,"MESH_RAD3")
-            
+            savereal(file, opts.mesh_rad3, "MESH_RAD3")
+
         if (opts.mesh_off2 is not None):
-            savereal(file,opts.mesh_off2,"MESH_OFF2")
+            savereal(file, opts.mesh_off2, "MESH_OFF2")
         if (opts.mesh_off3 is not None):
-            savereal(file,opts.mesh_off3,"MESH_OFF3")
-            
+            savereal(file, opts.mesh_off3, "MESH_OFF3")
+
         if (opts.mesh_snk2 is not None):
-            savereal(file,opts.mesh_snk2,"MESH_SNK2")
+            savereal(file, opts.mesh_snk2, "MESH_SNK2")
         if (opts.mesh_snk3 is not None):
-            savereal(file,opts.mesh_snk3,"MESH_SNK3")
-            
+            savereal(file, opts.mesh_snk3, "MESH_SNK3")
+
         if (opts.mesh_vol3 is not None):
-            savereal(file,opts.mesh_vol3,"MESH_VOL3")
-            
-    #------------------------------------------ OPTM options
+            savereal(file, opts.mesh_vol3, "MESH_VOL3")
+
+    # ------------------------------------------ OPTM options
         if (opts.optm_iter is not None):
-            saveints(file,opts.optm_iter,"OPTM_ITER")
-            
+            saveints(file, opts.optm_iter, "OPTM_ITER")
+
         if (opts.optm_qtol is not None):
-            savereal(file,opts.optm_qtol,"OPTM_QTOL")
+            savereal(file, opts.optm_qtol, "OPTM_QTOL")
         if (opts.optm_qlim is not None):
-            savereal(file,opts.optm_qlim,"OPTM_QLIM")
-    
+            savereal(file, opts.optm_qlim, "OPTM_QLIM")
+
         if (opts.optm_zip_ is not None):
-            savebool(file,opts.optm_zip_,"OPTM_ZIP_")
+            savebool(file, opts.optm_zip_, "OPTM_ZIP_")
         if (opts.optm_div_ is not None):
-            savebool(file,opts.optm_div_,"OPTM_DIV_")
+            savebool(file, opts.optm_div_, "OPTM_DIV_")
         if (opts.optm_tria is not None):
-            savebool(file,opts.optm_tria,"OPTM_TRIA")
+            savebool(file, opts.optm_tria, "OPTM_TRIA")
         if (opts.optm_dual is not None):
-            savebool(file,opts.optm_dual,"OPTM_DUAL")
-        
+            savebool(file, opts.optm_dual, "OPTM_DUAL")
+
     return
-
-
-

--- a/jigsawpy/savemsh.py
+++ b/jigsawpy/savemsh.py
@@ -4,89 +4,90 @@ from pathlib import Path
 from jigsawpy.msh_t import jigsaw_msh_t
 from jigsawpy.certify import certify
 
-def saveradii(mesh,file):
+
+def saveradii(mesh, file):
     """
     SAVERADII: save the RADII data structure to file.
-    
+
     """
-    if   (mesh.radii.size == +3):
-        file.write("RADII="\
-            f"{mesh.radii[0]:.18G};" \
-            f"{mesh.radii[1]:.18G};" \
-            f"{mesh.radii[2]:.18G}\n"\
-            )
+    if (mesh.radii.size == +3):
+        file.write("RADII="
+                   f"{mesh.radii[0]:.18G};"
+                   f"{mesh.radii[1]:.18G};"
+                   f"{mesh.radii[2]:.18G}\n"
+                   )
 
     elif (mesh.radii.size == +1):
-        file.write("RADII="\
-            f"{mesh.radii[0]:.18G};" \
-            f"{mesh.radii[0]:.18G};" \
-            f"{mesh.radii[0]:.18G}\n"\
-            )
+        file.write("RADII="
+                   f"{mesh.radii[0]:.18G};"
+                   f"{mesh.radii[0]:.18G};"
+                   f"{mesh.radii[0]:.18G}\n"
+                   )
 
     return
 
 
-def savevert2(mesh,file):
+def savevert2(mesh, file):
     """
     SAVEVERT2: save the POINT data structure to file.
-    
+
     """
-    file.write("POINT=" \
-        + str(mesh.vert2.size) + "\n")
+    file.write("POINT="
+               + str(mesh.vert2.size) + "\n")
 
     xpts = mesh.vert2["coord"]
     itag = mesh.vert2["IDtag"]
 
     for ipos in range(mesh.vert2.size):
-        file.write( \
-            f"{xpts[ipos,0]:.18G};"  \
-            f"{xpts[ipos,1]:.18G};"  \
-            f"{itag[ipos  ]}\n"  \
-            )
+        file.write(
+            f"{xpts[ipos,0]:.18G};"
+            f"{xpts[ipos,1]:.18G};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savevert3(mesh,file):
+def savevert3(mesh, file):
     """
     SAVEVERT3: save the POINT data structure to file.
-    
+
     """
-    file.write("POINT=" \
-        + str(mesh.vert3.size) + "\n")
+    file.write("POINT="
+               + str(mesh.vert3.size) + "\n")
 
     xpts = mesh.vert3["coord"]
     itag = mesh.vert3["IDtag"]
 
     for ipos in range(mesh.vert3.size):
         file.write(
-            f"{xpts[ipos,0]:.18G};"  \
-            f"{xpts[ipos,1]:.18G};"  \
-            f"{xpts[ipos,2]:.18G};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+            f"{xpts[ipos,0]:.18G};"
+            f"{xpts[ipos,1]:.18G};"
+            f"{xpts[ipos,2]:.18G};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savepower(mesh,file):
+def savepower(mesh, file):
     """
     SAVEPOWER: save the POWER data structure to file.
-    
-    """
-    npos = np.size(mesh.power,0)
-    npwr = np.size(mesh.power,1)
 
-    file.write ( "POWER=" + \
-        str(npos) + ";" + str(npwr) + "\n")
+    """
+    npos = np.size(mesh.power, 0)
+    npwr = np.size(mesh.power, 1)
+
+    file.write("POWER=" +
+               str(npos) + ";" + str(npwr) + "\n")
 
     data = mesh.power[:]
 
     for ipos in range(mesh.power.size):
         fstr = ""
-        for ipwr in range(npwr-1):
+        for ipwr in range(npwr - 1):
             fstr = fstr + \
-            f"{data[ipos,ipwr]:.18G};"
+                f"{data[ipos,ipwr]:.18G};"
         fstr = fstr + \
             f"{data[ipos,npwr]:.18G}\n"
 
@@ -95,24 +96,24 @@ def savepower(mesh,file):
     return
 
 
-def savevalue(mesh,file):
+def savevalue(mesh, file):
     """
     SAVEVALUE: save the VALUE data structure to file.
-    
-    """
-    npos = np.size(mesh.value,0)
-    nval = np.size(mesh.value,1)
 
-    file.write ( "VALUE=" + \
-        str(npos) + ";" + str(nval) + "\n")
+    """
+    npos = np.size(mesh.value, 0)
+    nval = np.size(mesh.value, 1)
+
+    file.write("VALUE=" +
+               str(npos) + ";" + str(nval) + "\n")
 
     data = mesh.value[:]
 
     for ipos in range(mesh.value.size):
         fstr = ""
-        for ival in range(nval-1):
+        for ival in range(nval - 1):
             fstr = fstr + \
-            f"{data[ipos,ival]:.18G};"
+                f"{data[ipos,ival]:.18G};"
         fstr = fstr + \
             f"{data[ipos,nval]:.18G}\n"
 
@@ -121,382 +122,380 @@ def savevalue(mesh,file):
     return
 
 
-def saveedge2(mesh,file):
+def saveedge2(mesh, file):
     """
     SAVEEDGE2: save the EDGE2 data structure to file.
-    
+
     """
-    file.write("EDGE2=" \
-        + str(mesh.edge2.size) + "\n")
+    file.write("EDGE2="
+               + str(mesh.edge2.size) + "\n")
 
     cell = mesh.edge2["index"]
     itag = mesh.edge2["IDtag"]
 
     for ipos in range(mesh.edge2.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savetria3(mesh,file):
+def savetria3(mesh, file):
     """
     SAVETRIA3: save the TRIA3 data structure to file.
-    
+
     """
-    file.write("TRIA3=" \
-        + str(mesh.tria3.size) + "\n")
+    file.write("TRIA3="
+               + str(mesh.tria3.size) + "\n")
 
     cell = mesh.tria3["index"]
     itag = mesh.tria3["IDtag"]
 
     for ipos in range(mesh.tria3.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savequad4(mesh,file):
+def savequad4(mesh, file):
     """
     SAVEQUAD4: save the QUAD4 data structure to file.
-    
+
     """
-    file.write("QUAD4=" \
-        + str(mesh.quad4.size) + "\n")
+    file.write("QUAD4="
+               + str(mesh.quad4.size) + "\n")
 
     cell = mesh.quad4["index"]
     itag = mesh.quad4["IDtag"]
 
     for ipos in range(mesh.quad4.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{cell[ipos,3]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{cell[ipos,3]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savetria4(mesh,file):
+def savetria4(mesh, file):
     """
     SAVETRIA4: save the TRIA4 data structure to file.
-    
+
     """
-    file.write("TRIA4=" \
-        + str(mesh.tria4.size) + "\n")
+    file.write("TRIA4="
+               + str(mesh.tria4.size) + "\n")
 
     cell = mesh.tria4["index"]
     itag = mesh.tria4["IDtag"]
 
     for ipos in range(mesh.tria4.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{cell[ipos,3]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{cell[ipos,3]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savehexa8(mesh,file):
+def savehexa8(mesh, file):
     """
     SAVEHEXA8: save the HEXA8 data structure to file.
-    
+
     """
-    file.write("HEXA8=" \
-        + str(mesh.hexa8.size) + "\n")
+    file.write("HEXA8="
+               + str(mesh.hexa8.size) + "\n")
 
     cell = mesh.hexa8["index"]
     itag = mesh.hexa8["IDtag"]
 
     for ipos in range(mesh.hexa8.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{cell[ipos,3]};"  \
-            f"{cell[ipos,4]};"  \
-            f"{cell[ipos,5]};"  \
-            f"{cell[ipos,6]};"  \
-            f"{cell[ipos,7]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{cell[ipos,3]};"
+            f"{cell[ipos,4]};"
+            f"{cell[ipos,5]};"
+            f"{cell[ipos,6]};"
+            f"{cell[ipos,7]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savewedg6(mesh,file):
+def savewedg6(mesh, file):
     """
     SAVEWEDG6: save the WEDG6 data structure to file.
-    
+
     """
-    file.write("WEDG6=" \
-        + str(mesh.wedg6.size) + "\n")
+    file.write("WEDG6="
+               + str(mesh.wedg6.size) + "\n")
 
     cell = mesh.wedg6["index"]
     itag = mesh.wedg6["IDtag"]
 
     for ipos in range(mesh.wedg6.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{cell[ipos,3]};"  \
-            f"{cell[ipos,4]};"  \
-            f"{cell[ipos,5]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{cell[ipos,3]};"
+            f"{cell[ipos,4]};"
+            f"{cell[ipos,5]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savepyra5(mesh,file):
+def savepyra5(mesh, file):
     """
     SAVEPYRA5: save the PYRA5 data structure to file.
-    
+
     """
-    file.write("PYRA5=" \
-        + str(mesh.pyra5.size) + "\n")
+    file.write("PYRA5="
+               + str(mesh.pyra5.size) + "\n")
 
     cell = mesh.pyra5["index"]
     itag = mesh.pyra5["IDtag"]
 
     for ipos in range(mesh.pyra5.size):
-        file.write( \
-            f"{cell[ipos,0]};"  \
-            f"{cell[ipos,1]};"  \
-            f"{cell[ipos,2]};"  \
-            f"{cell[ipos,3]};"  \
-            f"{cell[ipos,4]};"  \
-            f"{itag[ipos  ]}\n" \
-            )
+        file.write(
+            f"{cell[ipos,0]};"
+            f"{cell[ipos,1]};"
+            f"{cell[ipos,2]};"
+            f"{cell[ipos,3]};"
+            f"{cell[ipos,4]};"
+            f"{itag[ipos  ]}\n"
+        )
 
     return
 
 
-def savebound(mesh,file):
+def savebound(mesh, file):
     """
     SAVEBOUND: save the BOUND data structure to file.
-    
+
     """
-    file.write("BOUND=" \
-        + str(mesh.bound.size) + "\n")
+    file.write("BOUND="
+               + str(mesh.bound.size) + "\n")
 
     itag = mesh.bound["IDtag"]
     indx = mesh.bound["index"]
     kind = mesh.bound["cells"]
 
     for ipos in range(mesh.bound.size):
-        file.write( \
-            f"{itag[ipos  ]};"  \
-            f"{indx[ipos  ]};"  \
-            f"{kind[ipos  ]}\n" \
-            )
+        file.write(
+            f"{itag[ipos  ]};"
+            f"{indx[ipos  ]};"
+            f"{kind[ipos  ]}\n"
+        )
 
     return
 
 
-def savecoord(data,file,inum):
+def savecoord(data, file, inum):
     """
     SAVECOORD: save the COORD data structure to file.
-    
+
     """
-    file.write("COORD=" \
-        + str(inum) + ";" + str(data.size) + "\n")
+    file.write("COORD="
+               + str(inum) + ";" + str(data.size) + "\n")
 
     for ipos in range(data.size):
         file.write(f"{data[ipos]:.18G}\n"
-            )
+                   )
 
     return
 
 
-def savendmat(data,file):
+def savendmat(data, file):
     """
     SAVENDMAT: save the VALUE data structure to file.
-    
-    """
-    file.write("VALUE=" \
-        + str(np.prod(data.shape)) + ";+1" + "\n")
 
-    for iter in np.nditer(data,order="F"):
+    """
+    file.write("VALUE="
+               + str(np.prod(data.shape)) + ";+1" + "\n")
+
+    for iter in np.nditer(data, order="F"):
         file.write(f"{iter:.18G}\n")
 
     return
 
 
-def save_mesh_file(mesh,file,nver,kind):
+def save_mesh_file(mesh, file, nver, kind):
 
     file.write("MSHID=" + str(nver) + ";" + kind + "\n")
 
-    if (mesh.vert2 is not None and \
-        mesh.vert2.size != +0):
+    if (mesh.vert2 is not None and
+            mesh.vert2.size != +0):
 
-    #----------------------------------- write NDIMS struct.
+        # ----------------------------------- write NDIMS struct.
         file.write("NDIMS=2\n")
 
-    if (mesh.vert3 is not None and \
-        mesh.vert3.size != +0):
+    if (mesh.vert3 is not None and
+            mesh.vert3.size != +0):
 
-    #----------------------------------- write NDIMS struct.
+        # ----------------------------------- write NDIMS struct.
         file.write("NDIMS=3\n")
 
-    if (mesh.radii is not None and \
-        mesh.radii.size != +0):
+    if (mesh.radii is not None and
+            mesh.radii.size != +0):
 
-    #----------------------------------- write RADII struct.
-        saveradii(mesh,file)
- 
-    if (mesh.vert2 is not None and \
-        mesh.vert2.size != +0):
+        # ----------------------------------- write RADII struct.
+        saveradii(mesh, file)
 
-    #----------------------------------- write VERT2 struct.
-        savevert2(mesh,file)
+    if (mesh.vert2 is not None and
+            mesh.vert2.size != +0):
 
-    if (mesh.vert3 is not None and \
-        mesh.vert3.size != +0):
+        # ----------------------------------- write VERT2 struct.
+        savevert2(mesh, file)
 
-    #----------------------------------- write VERT3 struct.
-        savevert3(mesh,file)
+    if (mesh.vert3 is not None and
+            mesh.vert3.size != +0):
 
-    if (mesh.power is not None and \
-        mesh.power.size != +0):
+        # ----------------------------------- write VERT3 struct.
+        savevert3(mesh, file)
 
-    #----------------------------------- write POWER struct.
-        savepower(mesh,file)
+    if (mesh.power is not None and
+            mesh.power.size != +0):
 
-    if (mesh.value is not None and \
-        mesh.value.size != +0):
+        # ----------------------------------- write POWER struct.
+        savepower(mesh, file)
 
-    #----------------------------------- write VALUE struct.
-        savevalue(mesh,file)
+    if (mesh.value is not None and
+            mesh.value.size != +0):
 
-    if (mesh.edge2 is not None and \
-        mesh.edge2.size != +0):
+        # ----------------------------------- write VALUE struct.
+        savevalue(mesh, file)
 
-    #----------------------------------- write EDGE2 struct.
-        saveedge2(mesh,file)
+    if (mesh.edge2 is not None and
+            mesh.edge2.size != +0):
 
-    if (mesh.tria3 is not None and \
-        mesh.tria3.size != +0):
+        # ----------------------------------- write EDGE2 struct.
+        saveedge2(mesh, file)
 
-    #----------------------------------- write TRIA3 struct.
-        savetria3(mesh,file)
+    if (mesh.tria3 is not None and
+            mesh.tria3.size != +0):
 
-    if (mesh.quad4 is not None and \
-        mesh.quad4.size != +0):
+        # ----------------------------------- write TRIA3 struct.
+        savetria3(mesh, file)
 
-    #----------------------------------- write QUAD4 struct.
-        savequad4(mesh,file)
+    if (mesh.quad4 is not None and
+            mesh.quad4.size != +0):
 
-    if (mesh.tria4 is not None and \
-        mesh.tria4.size != +0):
+        # ----------------------------------- write QUAD4 struct.
+        savequad4(mesh, file)
 
-    #----------------------------------- write TRIA4 struct.
-        savetria4(mesh,file)
+    if (mesh.tria4 is not None and
+            mesh.tria4.size != +0):
 
-    if (mesh.hexa8 is not None and \
-        mesh.hexa8.size != +0):
+        # ----------------------------------- write TRIA4 struct.
+        savetria4(mesh, file)
 
-    #----------------------------------- write HEXA8 struct.
-        savehexa8(mesh,file)
+    if (mesh.hexa8 is not None and
+            mesh.hexa8.size != +0):
 
-    if (mesh.wedg6 is not None and \
-        mesh.wedg6.size != +0):
+        # ----------------------------------- write HEXA8 struct.
+        savehexa8(mesh, file)
 
-    #----------------------------------- write WEDG6 struct.
-        savewedg6(mesh,file)
+    if (mesh.wedg6 is not None and
+            mesh.wedg6.size != +0):
 
-    if (mesh.pyra5 is not None and \
-        mesh.pyra5.size != +0):
+        # ----------------------------------- write WEDG6 struct.
+        savewedg6(mesh, file)
 
-    #----------------------------------- write PYRA5 struct.
-        savepyra5(mesh,file)
+    if (mesh.pyra5 is not None and
+            mesh.pyra5.size != +0):
 
-    if (mesh.bound is not None and \
-        mesh.bound.size != +0):
+        # ----------------------------------- write PYRA5 struct.
+        savepyra5(mesh, file)
 
-    #----------------------------------- write BOUND struct.
-        savebound(mesh,file)
-        
+    if (mesh.bound is not None and
+            mesh.bound.size != +0):
+
+        # ----------------------------------- write BOUND struct.
+        savebound(mesh, file)
 
     return
 
 
-def save_grid_file(mesh,file,nver,kind):
+def save_grid_file(mesh, file, nver, kind):
 
     file.write("MSHID=" + str(nver) + ";" + kind + "\n")
 
-    if (mesh.radii is not None and \
-        mesh.radii.size != +0):
+    if (mesh.radii is not None and
+            mesh.radii.size != +0):
 
-    #----------------------------------- write RADII struct.
-        saveradii(mesh.radii,file)
+        # ----------------------------------- write RADII struct.
+        saveradii(mesh.radii, file)
 
-    #----------------------------------- calc. NDIMS struct.
-    ndim =  +0
+    # ----------------------------------- calc. NDIMS struct.
+    ndim = +0
 
-    if (mesh.xgrid is not None and \
-        mesh.xgrid.size != +0):
-
-        ndim += +1
-
-    if (mesh.ygrid is not None and \
-        mesh.ygrid.size != +0):
+    if (mesh.xgrid is not None and
+            mesh.xgrid.size != +0):
 
         ndim += +1
 
-    if (mesh.zgrid is not None and \
-        mesh.zgrid.size != +0):
+    if (mesh.ygrid is not None and
+            mesh.ygrid.size != +0):
+
+        ndim += +1
+
+    if (mesh.zgrid is not None and
+            mesh.zgrid.size != +0):
 
         ndim += +1
 
     if (ndim >= +1):
-    #----------------------------------- write NDIMS struct.
+        # ----------------------------------- write NDIMS struct.
         file.write(
-        "NDIMS=" + str(ndim) + "\n")
+            "NDIMS=" + str(ndim) + "\n")
 
+    if (mesh.xgrid is not None and
+            mesh.xgrid.size != +0):
 
-    if (mesh.xgrid is not None and \
-        mesh.xgrid.size != +0):
+        # ----------------------------------- write XGRID struct.
+        savecoord(mesh.xgrid, file, 1)
 
-    #----------------------------------- write XGRID struct.
-        savecoord(mesh.xgrid,file,1)
+    if (mesh.ygrid is not None and
+            mesh.ygrid.size != +0):
 
-    if (mesh.ygrid is not None and \
-        mesh.ygrid.size != +0):
+        # ----------------------------------- write YGRID struct.
+        savecoord(mesh.ygrid, file, 2)
 
-    #----------------------------------- write YGRID struct.
-        savecoord(mesh.ygrid,file,2)
+    if (mesh.zgrid is not None and
+            mesh.zgrid.size != +0):
 
-    if (mesh.zgrid is not None and \
-        mesh.zgrid.size != +0):
+        # ----------------------------------- write ZGRID struct.
+        savecoord(mesh.zgrid, file, 3)
 
-    #----------------------------------- write ZGRID struct.
-        savecoord(mesh.zgrid,file,3)
+    if (mesh.value is not None and
+            mesh.value.size != +0):
 
-    if (mesh.value is not None and \
-        mesh.value.size != +0):
-
-    #----------------------------------- write VALUE struct.
-        savendmat(mesh.value,file)
+        # ----------------------------------- write VALUE struct.
+        savendmat(mesh.value, file)
 
     return
 
 
-def savemsh(name,mesh):
+def savemsh(name, mesh):
     """
     SAVEMSH: save a JIGSAW MSH object to file.
 
@@ -507,48 +506,45 @@ def savemsh(name,mesh):
 
     Data in MESH is written as-needed -- any objects defined
     will be saved to file.
-    
+
     """
 
-    if (not isinstance(name,str)):
+    if (not isinstance(name, str)):
         raise Exception("Incorrect type: NAME.")
-        
-    if (not isinstance(mesh,jigsaw_msh_t)):
+
+    if (not isinstance(mesh, jigsaw_msh_t)):
         raise Exception("Incorrect type: MESH.")
 
-    nver =  +3
+    nver = +3
 
     certify(mesh)
 
     fext = Path(name).suffix
-    
+
     if (fext.strip() != ".msh"):
-        name =   name + ".msh"
+        name = name + ".msh"
 
     kind = mesh.mshID.lower()
 
     with Path(name).open("w") as file:
-    #----------------------------------- write JIGSAW object    
-        file.write("# " + Path(name).name + \
-    "; created by JIGSAW's PYTHON interface \n")
-   
+        # ----------------------------------- write JIGSAW object
+        file.write("# " + Path(name).name +
+                   "; created by JIGSAW's PYTHON interface \n")
+
         if (kind == "euclidean-mesh"):
-            save_mesh_file( \
-            mesh,file,nver,"euclidean-mesh")
+            save_mesh_file(
+                mesh, file, nver, "euclidean-mesh")
 
         if (kind == "euclidean-grid"):
-            save_grid_file( \
-            mesh,file,nver,"euclidean-grid")
+            save_grid_file(
+                mesh, file, nver, "euclidean-grid")
 
         if (kind == "ellipsoid-mesh"):
-            save_mesh_file( \
-            mesh,file,nver,"ellipsoid-mesh")
+            save_mesh_file(
+                mesh, file, nver, "ellipsoid-mesh")
 
         if (kind == "ellipsoid-grid"):
-            save_grid_file( \
-            mesh,file,nver,"ellipsoid-grid")
+            save_grid_file(
+                mesh, file, nver, "ellipsoid-grid")
 
     return
-    
-
-    

--- a/tests/case_1_.py
+++ b/tests/case_1_.py
@@ -7,14 +7,14 @@
 *
 """
 
-from pathlib import Path
 import numpy as np
 
 import jigsawpy
- 
+
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 from matplotlib.collections import LineCollection
+
 
 def case_1a(savefigs=False):
 
@@ -23,62 +23,62 @@ def case_1a(savefigs=False):
     geom = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ define JIGSAW geometry
-    
+# ------------------------------------ define JIGSAW geometry
+
     geom.mshID = "euclidean-mesh"
-    geom.vert2 = np.array([ # list of xy "node" coordinate
-      ((0, 0), 0),          # outer square
-      ((9, 0), 0),
-      ((9, 9), 0),
-      ((0, 9), 0),
-      ((4, 4), 0),          # inner square
-      ((5, 4), 0),
-      ((5, 5), 0),
-      ((4, 5), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
+    geom.vert2 = np.array([  # list of xy "node" coordinate
+        ((0, 0), 0),          # outer square
+        ((9, 0), 0),
+        ((9, 9), 0),
+        ((0, 9), 0),
+        ((4, 4), 0),          # inner square
+        ((5, 4), 0),
+        ((5, 5), 0),
+        ((4, 5), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
 
-    geom.edge2 = np.array([ # list of "edges" between vert
-      ((0, 1), 0),          # outer square 
-      ((1, 2), 0),
-      ((2, 3), 0),
-      ((3, 0), 0),
-      ((4, 5), 0),          # inner square
-      ((5, 6), 0),
-      ((6, 7), 0),
-      ((7, 4), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
+    geom.edge2 = np.array([  # list of "edges" between vert
+        ((0, 1), 0),          # outer square
+        ((1, 2), 0),
+        ((2, 3), 0),
+        ((3, 0), 0),
+        ((4, 5), 0),          # inner square
+        ((5, 6), 0),
+        ((6, 7), 0),
+        ((7, 4), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
-#------------------------------------ build mesh via JIGSAW! 
-  
+# ------------------------------------ build mesh via JIGSAW!
+
     print("Call libJIGSAW: case 1a.")
 
     opts.hfun_hmax = 0.05               # null HFUN limits
-   
+
     opts.mesh_dims = +2                 # 2-dim. simplexes
-    
-    opts.optm_qlim = +.95  
-   
+
+    opts.optm_qlim = +.95
+
     opts.mesh_top1 = True               # for sharp feat's
-    opts.geom_feat = True  
-    
-    jigsawpy.lib.jigsaw(opts,geom,mesh)  
+    opts.geom_feat = True
+
+    jigsawpy.lib.jigsaw(opts, geom, mesh)
 
     fig = plt.figure(1)
-    axi = fig.add_subplot(1,1,1)
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"]),linewidth=0.500)
-    
+    axi = fig.add_subplot(1, 1, 1)
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"]), linewidth=0.500)
+
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k") 
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
-    
+
     return
 
 
@@ -89,86 +89,86 @@ def case_1b(savefigs=False):
     geom = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ define JIGSAW geometry
-    
+# ------------------------------------ define JIGSAW geometry
+
     geom.mshID = "euclidean-mesh"
-    geom.vert2 = np.array([ # list of xy "node" coordinate
-      ((0, 0), 0),          # outer square
-      ((9, 0), 0),
-      ((9, 9), 0),
-      ((0, 9), 0),
-      ((2, 2), 0),          # inner square
-      ((7, 2), 0),
-      ((7, 7), 0),
-      ((2, 7), 0),
-      ((3, 3), 0),
-      ((6, 6), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
+    geom.vert2 = np.array([  # list of xy "node" coordinate
+        ((0, 0), 0),          # outer square
+        ((9, 0), 0),
+        ((9, 9), 0),
+        ((0, 9), 0),
+        ((2, 2), 0),          # inner square
+        ((7, 2), 0),
+        ((7, 7), 0),
+        ((2, 7), 0),
+        ((3, 3), 0),
+        ((6, 6), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
 
-    geom.edge2 = np.array([ # list of "edges" between vert
-      ((0, 1), 0),          # outer square 
-      ((1, 2), 0),
-      ((2, 3), 0),
-      ((3, 0), 0),
-      ((4, 5), 0),          # inner square
-      ((5, 6), 0),
-      ((6, 7), 0),
-      ((7, 4), 0),
-      ((8, 9), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
+    geom.edge2 = np.array([  # list of "edges" between vert
+        ((0, 1), 0),          # outer square
+        ((1, 2), 0),
+        ((2, 3), 0),
+        ((3, 0), 0),
+        ((4, 5), 0),          # inner square
+        ((5, 6), 0),
+        ((6, 7), 0),
+        ((7, 4), 0),
+        ((8, 9), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
-    et =  jigsawpy.\
-          jigsaw_def_t.JIGSAW_EDGE2_TAG
+    et = jigsawpy.\
+        jigsaw_def_t.JIGSAW_EDGE2_TAG
 
     geom.bound = np.array([
-       (1, 0, et),
-       (1, 1, et),
-       (1, 2, et),
-       (1, 3, et),
-       (1, 4, et),
-       (1, 5, et),
-       (1, 6, et),
-       (1, 7, et),
-       (2, 4, et),
-       (2, 5, et),
-       (2, 6, et),
-       (2, 7, et)] ,
-    dtype=jigsawpy.jigsaw_msh_t.BOUND_t)
-    
-#------------------------------------ build mesh via JIGSAW! 
-  
+        (1, 0, et),
+        (1, 1, et),
+        (1, 2, et),
+        (1, 3, et),
+        (1, 4, et),
+        (1, 5, et),
+        (1, 6, et),
+        (1, 7, et),
+        (2, 4, et),
+        (2, 5, et),
+        (2, 6, et),
+        (2, 7, et)],
+        dtype=jigsawpy.jigsaw_msh_t.BOUND_t)
+
+# ------------------------------------ build mesh via JIGSAW!
+
     print("Call libJIGSAW: case 1b.")
 
     opts.hfun_hmax = 0.05               # null HFUN limits
     opts.mesh_dims = +2                 # 2-dim. simplexes
-    
-    opts.optm_qlim = +.95  
-   
+
+    opts.optm_qlim = +.95
+
     opts.mesh_top1 = True               # for sharp feat's
-    opts.geom_feat = True  
-    
-    jigsawpy.lib.jigsaw(opts,geom,mesh)  
+    opts.geom_feat = True
+
+    jigsawpy.lib.jigsaw(opts, geom, mesh)
 
     fig = plt.figure(2)
-    axi = fig.add_subplot(1,1,1)
-    P1= mesh.tria3["IDtag"] == 1        # TRIA in 1st part  
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-    mesh.tria3["index"][P1,:]),linewidth=0.5)
-    P2= mesh.tria3["IDtag"] == 2        # TRIA in 2nd part  
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-    mesh.tria3["index"][P2,:]),linewidth=0.5,
-        color= "red")
+    axi = fig.add_subplot(1, 1, 1)
+    P1 = mesh.tria3["IDtag"] == 1        # TRIA in 1st part
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"][P1, :]), linewidth=0.5)
+    P2 = mesh.tria3["IDtag"] == 2        # TRIA in 2nd part
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"][P2, :]), linewidth=0.5,
+        color="red")
 
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k") 
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
 
@@ -183,96 +183,96 @@ def case_1c(savefigs=False):
     hmat = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ define JIGSAW geometry
-    
+# ------------------------------------ define JIGSAW geometry
+
     geom.mshID = "euclidean-mesh"
-    geom.vert2 = np.array([ # list of xy "node" coordinate
-      ((0, 0), 0),          # outer square
-      ((9, 0), 0),
-      ((9, 9), 0),
-      ((0, 9), 0),
-      ((4, 4), 0),          # inner square
-      ((5, 4), 0),
-      ((5, 5), 0),
-      ((4, 5), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
+    geom.vert2 = np.array([  # list of xy "node" coordinate
+        ((0, 0), 0),          # outer square
+        ((9, 0), 0),
+        ((9, 9), 0),
+        ((0, 9), 0),
+        ((4, 4), 0),          # inner square
+        ((5, 4), 0),
+        ((5, 5), 0),
+        ((4, 5), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
 
-    geom.edge2 = np.array([ # list of "edges" between vert
-      ((0, 1), 0),          # outer square 
-      ((1, 2), 0),
-      ((2, 3), 0),
-      ((3, 0), 0),
-      ((4, 5), 0),          # inner square
-      ((5, 6), 0),
-      ((6, 7), 0),
-      ((7, 4), 0)] ,
-    dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
-   
-#------------------------------------ compute HFUN over GEOM    
-        
-    xgeo = geom.vert2["coord"][:,0]
-    ygeo = geom.vert2["coord"][:,1]
+    geom.edge2 = np.array([  # list of "edges" between vert
+        ((0, 1), 0),          # outer square
+        ((1, 2), 0),
+        ((2, 3), 0),
+        ((3, 0), 0),
+        ((4, 5), 0),          # inner square
+        ((5, 6), 0),
+        ((6, 7), 0),
+        ((7, 4), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
-    xpos = np.linspace( 
-        xgeo.min(),xgeo.max(), 128)
-                    
+# ------------------------------------ compute HFUN over GEOM
+
+    xgeo = geom.vert2["coord"][:, 0]
+    ygeo = geom.vert2["coord"][:, 1]
+
+    xpos = np.linspace(
+        xgeo.min(), xgeo.max(), 128)
+
     ypos = np.linspace(
-        ygeo.min(),ygeo.max(), 128)
+        ygeo.min(), ygeo.max(), 128)
 
     xmat, ymat = np.meshgrid(xpos, ypos)
 
-    hfun =-.4*np.exp(-.1*(xmat-4.5)**2 \
-                     -.1*(ymat-4.5)**2 \
-            ) + .6
+    hfun = -.4 * np.exp(-.1 * (xmat - 4.5)**2
+                        - .1 * (ymat - 4.5)**2
+                        ) + .6
 
     hmat.mshID = "euclidean-grid"
     hmat.xgrid = np.array(xpos,
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+                          dtype=jigsawpy.jigsaw_msh_t.REALS_t)
     hmat.ygrid = np.array(ypos,
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+                          dtype=jigsawpy.jigsaw_msh_t.REALS_t)
     hmat.value = np.array(hfun,
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+                          dtype=jigsawpy.jigsaw_msh_t.REALS_t)
 
-#------------------------------------ build mesh via JIGSAW! 
-  
+# ------------------------------------ build mesh via JIGSAW!
+
     print("Call libJIGSAW: case 1c.")
 
     opts.hfun_scal = "absolute"
     opts.hfun_hmax = float("inf")       # null HFUN limits
-    opts.hfun_hmin = float(+0.00)  
-   
+    opts.hfun_hmin = float(+0.00)
+
     opts.mesh_dims = +2                 # 2-dim. simplexes
-    
-    opts.optm_qlim = +.95  
-   
+
+    opts.optm_qlim = +.95
+
     opts.mesh_top1 = True               # for sharp feat's
-    opts.geom_feat = True  
-    
-    jigsawpy.lib.jigsaw(opts,geom,mesh,
-                        None,hmat)  
+    opts.geom_feat = True
+
+    jigsawpy.lib.jigsaw(opts, geom, mesh,
+                        None, hmat)
 
     fig = plt.figure(3)
-    axi = fig.add_subplot(1,1,1)    
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"]),linewidth=0.500)
-    
+    axi = fig.add_subplot(1, 1, 1)
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"]), linewidth=0.500)
+
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k") 
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
 
     return
 
 
-def case_1_(filepath,savefigs=False):
+def case_1_(filepath, savefigs=False):
 
-#------------------------------------ build various examples
+    # ------------------------------------ build various examples
 
     case_1a(savefigs)
     case_1b(savefigs)
@@ -285,9 +285,7 @@ def case_1_(filepath,savefigs=False):
         plt.savefig("case_1b.png")
         plt.figure(3)
         plt.savefig("case_1c.png")
-    else: plt.show ()
+    else:
+        plt.show()
 
     return
-
-
-

--- a/tests/case_2_.py
+++ b/tests/case_2_.py
@@ -18,18 +18,19 @@ import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 from matplotlib.collections import LineCollection
 
-def case_2_(filepath,savefigs=False):
 
-#------------------------------------ define JIGSAW geometry
+def case_2_(filepath, savefigs=False):
+
+    # ------------------------------------ define JIGSAW geometry
 
     geom_file = \
-        str (Path(filepath)/"lake.msh")
+        str(Path(filepath) / "lake.msh")
 
     geom = jigsawpy.jigsaw_msh_t()
 
     jigsawpy.loadmsh(geom_file, geom)
 
-#------------------------------------ the lo-resolution case
+# ------------------------------------ the lo-resolution case
 
     print("Call libJIGSAW: case 2a.")
 
@@ -40,25 +41,25 @@ def case_2_(filepath,savefigs=False):
     opts.mesh_dims = +2
     opts.mesh_rad2 = +1.20
 
-    jigsawpy.lib.jigsaw(opts,geom,mesh)
+    jigsawpy.lib.jigsaw(opts, geom, mesh)
 
     fig = plt.figure(1)
-    axi = fig.add_subplot(1,1,1)
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"]),linewidth=0.500)
+    axi = fig.add_subplot(1, 1, 1)
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"]), linewidth=0.500)
 
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k")
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
 
-#------------------------------------ the hi-resolution case
+# ------------------------------------ the hi-resolution case
 
     print("Call libJIGSAW: case 2b.")
 
@@ -69,21 +70,21 @@ def case_2_(filepath,savefigs=False):
     opts.mesh_dims = +2
     opts.mesh_rad2 = +1.20
 
-    jigsawpy.lib.jigsaw(opts,geom,mesh)
+    jigsawpy.lib.jigsaw(opts, geom, mesh)
 
     fig = plt.figure(2)
-    axi = fig.add_subplot(1,1,1)
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"]),linewidth=0.500)
+    axi = fig.add_subplot(1, 1, 1)
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"]), linewidth=0.500)
 
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k")
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
 
@@ -92,9 +93,7 @@ def case_2_(filepath,savefigs=False):
         plt.savefig("case_2a.png")
         plt.figure(2)
         plt.savefig("case_2b.png")
-    else: plt.show ()
+    else:
+        plt.show()
 
     return
-
-
-

--- a/tests/case_3_.py
+++ b/tests/case_3_.py
@@ -11,12 +11,13 @@ from pathlib import Path
 import numpy as np
 
 import jigsawpy
- 
+
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 from matplotlib.collections import LineCollection
 
-def case_3_(filepath,savefigs=False):
+
+def case_3_(filepath, savefigs=False):
 
     opts = jigsawpy.jigsaw_jig_t()
 
@@ -25,125 +26,125 @@ def case_3_(filepath,savefigs=False):
     hmat = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ setup files for JIGSAW
+# ------------------------------------ setup files for JIGSAW
 
     opts.geom_file = \
-        str(Path(filepath)/"aust.msh")  # GEOM file
-        
+        str(Path(filepath) / "aust.msh")  # GEOM file
+
     opts.jcfg_file = \
-        str(Path(filepath)/"aust.jig")  # JCFG file
-    
+        str(Path(filepath) / "aust.jig")  # JCFG file
+
     opts.mesh_file = \
-        str(Path(filepath)/"mesh.msh")  # MESH file
-    
+        str(Path(filepath) / "mesh.msh")  # MESH file
+
     opts.hfun_file = \
-        str(Path(filepath)/"hfun.msh")  # HFUN file
+        str(Path(filepath) / "hfun.msh")  # HFUN file
 
-#------------------------------------ setup TOPO for spacing
+# ------------------------------------ setup TOPO for spacing
 
-    print ("Load topo-data: case 3a.")
+    print("Load topo-data: case 3a.")
 
     geom_file = \
-        str(Path(filepath)/"aust.msh")
+        str(Path(filepath) / "aust.msh")
 
     topo_file = \
-        str(Path(filepath)/"topo.msh")
+        str(Path(filepath) / "topo.msh")
 
-    jigsawpy.loadmsh(geom_file,geom)
-    jigsawpy.loadmsh(topo_file,topo)
+    jigsawpy.loadmsh(geom_file, geom)
+    jigsawpy.loadmsh(topo_file, topo)
 
     topo.value = topo.value.reshape(
-      (topo.xgrid.size,topo.ygrid.size)).T
-   
+        (topo.xgrid.size, topo.ygrid.size)).T
+
     xgeo = geom.vert2["coord"][:, 0]
     ygeo = geom.vert2["coord"][:, 1]
 
-    xmin = xgeo.min(); xmax = xgeo.max()
-    ymin = ygeo.min(); ymax = ygeo.max()
+    xmin = xgeo.min()
+    xmax = xgeo.max()
+    ymin = ygeo.min()
+    ymax = ygeo.max()
 
     ipos = np.argwhere(
         np.logical_and(
-    topo.xgrid>=xmin, topo.xgrid<=xmax))
+            topo.xgrid >= xmin, topo.xgrid <= xmax))
 
-    ione = int(ipos[+1]-1)
-    iend = int(ipos[-1]+2)
+    ione = int(ipos[+1] - 1)
+    iend = int(ipos[-1] + 2)
 
     jpos = np.argwhere(
         np.logical_and(
-    topo.ygrid>=ymin, topo.ygrid<=ymax))
+            topo.ygrid >= ymin, topo.ygrid <= ymax))
 
-    jone = int(jpos[+1]-1)
-    jend = int(jpos[-1]+2)
+    jone = int(jpos[+1] - 1)
+    jend = int(jpos[-1] + 2)
 
-#------------------------------------ compute HFUN over TOPO
+# ------------------------------------ compute HFUN over TOPO
 
     hmat.mshID = "euclidean-grid"
     hmat.xgrid = np.array(
         topo.xgrid[ione:iend],
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+        dtype=jigsawpy.jigsaw_msh_t.REALS_t)
     hmat.ygrid = np.array(
         topo.ygrid[jone:jend],
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+        dtype=jigsawpy.jigsaw_msh_t.REALS_t)
     hmat.value = np.array(
-        topo.value[jone:jend,ione:iend],
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+        topo.value[jone:jend, ione:iend],
+        dtype=jigsawpy.jigsaw_msh_t.REALS_t)
 
     hmat.value = np.sqrt(
-        np.maximum(-hmat.value,+0.0) )
+        np.maximum(-hmat.value, +0.0))
     hmat.value *= 2.
 
     hmat.value = \
         np.maximum(hmat.value, +10.)
     hmat.value = \
-        np.minimum(hmat.value,+100.)
+        np.minimum(hmat.value, +100.)
 
     hmat.value /= 100.
 
-    jigsawpy.savemsh(opts.hfun_file,hmat)
-   
-#------------------------------------ build mesh via JIGSAW!
+    jigsawpy.savemsh(opts.hfun_file, hmat)
+
+# ------------------------------------ build mesh via JIGSAW!
 
     opts.hfun_scal = "absolute"
-    opts.hfun_hmax = float ("inf")      # null HFUN limits
-    opts.hfun_hmin = float (+0.00)  
-   
+    opts.hfun_hmax = float("inf")      # null HFUN limits
+    opts.hfun_hmin = float(+0.00)
+
     opts.mesh_dims = +2                 # 2-dim. simplexes
-    
+
     opts.mesh_eps1 = +1.00
 
     opts.optm_qlim = +0.80
 
-    jigsawpy.cmd.jigsaw(opts,mesh)  
+    jigsawpy.cmd.jigsaw(opts, mesh)
 
     fig = plt.figure(1)
-    axi = fig.add_subplot(1,1,1)    
-    axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"]),linewidth=0.500)
+    axi = fig.add_subplot(1, 1, 1)
+    axi.triplot(tri.Triangulation(
+        mesh.vert2["coord"][:, 0],
+        mesh.vert2["coord"][:, 1],
+        mesh.tria3["index"]), linewidth=0.500)
 
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k") 
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
-    
+
     fig = plt.figure(2)
     plt.contourf(
-            hmat.xgrid,hmat.ygrid,hmat.value)
+        hmat.xgrid, hmat.ygrid, hmat.value)
     plt.axis("equal")
-    
+
     if savefigs:
         plt.figure(1)
         plt.savefig("case_3a.png")
         plt.figure(2)
         plt.savefig("case_3b.png")
-    else: plt.show ()
-    
+    else:
+        plt.show()
+
     return
-
-
-

--- a/tests/case_4_.py
+++ b/tests/case_4_.py
@@ -11,72 +11,69 @@ from pathlib import Path
 import numpy as np
 
 import jigsawpy
- 
+
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 from matplotlib.collections import LineCollection
 
-def case_4_(filepath,savefigs=False):
+
+def case_4_(filepath, savefigs=False):
 
     opts = jigsawpy.jigsaw_jig_t()
 
-    topo = jigsawpy.jigsaw_msh_t()
     geom = jigsawpy.jigsaw_msh_t()
-    hmat = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ setup files for JIGSAW
+# ------------------------------------ setup files for JIGSAW
 
     opts.geom_file = \
-        str(Path(filepath)/"us48.msh")  # GEOM file
-        
-    opts.jcfg_file = \
-        str(Path(filepath)/"us48.jig")  # JCFG file
-    
-    opts.mesh_file = \
-        str(Path(filepath)/"mesh.msh")  # MESH file
+        str(Path(filepath) / "us48.msh")  # GEOM file
 
-#------------------------------------ build mesh via JIGSAW!
+    opts.jcfg_file = \
+        str(Path(filepath) / "us48.jig")  # JCFG file
+
+    opts.mesh_file = \
+        str(Path(filepath) / "mesh.msh")  # MESH file
+
+# ------------------------------------ build mesh via JIGSAW!
 
     jigsawpy.loadmsh(
-              opts.geom_file,geom)
+        opts.geom_file, geom)
 
     opts.hfun_hmax = .005
-    
+
     opts.mesh_dims = +2                 # 2-dim. simplexes
-    opts.mesh_eps1 = +1/6.
-    
+    opts.mesh_eps1 = +1 / 6.
+
     opts.optm_qlim = +.90
 
-    jigsawpy.cmd.jigsaw(opts,mesh)
+    jigsawpy.cmd.jigsaw(opts, mesh)
 
     fig = plt.figure(1)
-    axi = fig.add_subplot(1,1,1) 
-    ttag = mesh.tria3["IDtag"]   
+    axi = fig.add_subplot(1, 1, 1)
+    ttag = mesh.tria3["IDtag"]
     for ptag in range(ttag.max()):
         pt = ttag == ptag
-        if (pt.any()): \
-        axi.triplot(tri.Triangulation( \
-        mesh.vert2["coord"][:, 0], \
-        mesh.vert2["coord"][:, 1], \
-        mesh.tria3["index"][pt,:]) , \
-    linewidth=0.500,color=np.random.rand(3,))
+        if (pt.any()):
+                    axi.triplot(tri.Triangulation(
+                        mesh.vert2["coord"][:, 0],
+                        mesh.vert2["coord"][:, 1],
+                        mesh.tria3["index"][pt, :]),
+                        linewidth=0.500, color=np.random.rand(3,))
 
     vert = geom.vert2["coord"]
     edge = geom.edge2["index"]
     eONE = vert[edge[:, 0], :]
     eTWO = vert[edge[:, 1], :]
     line = LineCollection(
-      np.stack((eONE,eTWO),axis=1),color="k") 
+        np.stack((eONE, eTWO), axis=1), color="k")
     axi.add_collection(line)
     plt.axis("equal")
-    
+
     if savefigs:
         plt.figure(1)
         plt.savefig("case_4_.png")
-    else: plt.show ()
+    else:
+        plt.show()
 
     return
-
-
-

--- a/tests/case_5_.py
+++ b/tests/case_5_.py
@@ -15,35 +15,36 @@ from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 
-def case_5_(filepath,savefigs=False):
+
+def case_5_(filepath, savefigs=False):
 
     opts = jigsawpy.jigsaw_jig_t()
 
     geom = jigsawpy.jigsaw_msh_t()
     mesh = jigsawpy.jigsaw_msh_t()
 
-#------------------------------------ setup files for JIGSAW
+# ------------------------------------ setup files for JIGSAW
 
     opts.geom_file = \
-        str(Path(filepath)/"ball.msh")  # GEOM file
+        str(Path(filepath) / "ball.msh")  # GEOM file
 
     opts.jcfg_file = \
-        str(Path(filepath)/"ball.jig")  # JCFG file
+        str(Path(filepath) / "ball.jig")  # JCFG file
 
     opts.mesh_file = \
-        str(Path(filepath)/"mesh.msh")  # MESH file
+        str(Path(filepath) / "mesh.msh")  # MESH file
 
-#------------------------------------ define JIGSAW geometry
+# ------------------------------------ define JIGSAW geometry
 
     geom.mshID = "ellipsoid-mesh"
     geom.radii = np.array(
         [+6371., +6371., +6371.],
-    dtype=jigsawpy.jigsaw_msh_t.REALS_t)
+        dtype=jigsawpy.jigsaw_msh_t.REALS_t)
 
     jigsawpy.savemsh(
-              opts.geom_file,geom)
+        opts.geom_file, geom)
 
-#------------------------------------ build mesh via JIGSAW!
+# ------------------------------------ build mesh via JIGSAW!
 
     opts.hfun_scal = "absolute"
     opts.hfun_hmax = +200.
@@ -52,24 +53,22 @@ def case_5_(filepath,savefigs=False):
 
     opts.optm_qlim = +.95
 
-    jigsawpy.cmd.jigsaw(opts,mesh)
+    jigsawpy.cmd.jigsaw(opts, mesh)
 
     fig = plt.figure(1)
     axi = fig.add_subplot(111, projection="3d")
     axi.plot_trisurf(
-        mesh.vert3["coord"][:, 0], \
-        mesh.vert3["coord"][:, 1], \
-        mesh.vert3["coord"][:, 2], \
-    triangles=mesh.tria3["index"], \
-    edgecolor="black",color="white", \
-    linewidth=0.1000,alpha=0.7500)
+        mesh.vert3["coord"][:, 0],
+        mesh.vert3["coord"][:, 1],
+        mesh.vert3["coord"][:, 2],
+        triangles=mesh.tria3["index"],
+        edgecolor="black", color="white",
+        linewidth=0.1000, alpha=0.7500)
 
     if savefigs:
         plt.figure(1)
         plt.savefig("case_5_.png")
-    else: plt.show ()
+    else:
+        plt.show()
 
     return
-
-
-


### PR DESCRIPTION
I would highly recommend following the PEP8 code style:
https://www.python.org/dev/peps/pep-0008/

There is a package, `autopep8`, that does a nice job of modifying your code to automatically conform to the style:
```
autopep8 --in-place --aggressive *.py
```
I applied this to all the python code.  Please consider either merging this PR or applying this technique yourself.  It would make your code a lot more readable to me and other python developers.

I use an IDE called `spyder` that can automatically detect PEP8 formatting errors as I develop.  It also flags unused imports and variables (and other coding errors of that nature).  I used this to remove unused variable and imports.  Other IDEs like `pycharm` will also do this (but `pycharm` is, I believe, not open source so I don't use it).

`spyder` also flagged a problem in `certify.py` that I will post a separate issue for.